### PR TITLE
Compiler directive for debug output

### DIFF
--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -23,6 +23,19 @@
 #define HEX_CHAR_TO_NIBBLE(c) ((c >= 'A') ? (c - 'A' + 0x0A) : (c - '0'))
 #define HEX_PAIR_TO_BYTE(h, l) ((HEX_CHAR_TO_NIBBLE(h) << 4) + HEX_CHAR_TO_NIBBLE(l))
 
+/* BEGIN TEST */
+
+#ifdef DEBUG
+  #warning Debug mode
+  #define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
+  #define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
+#else
+  #define debugPrintLn(...)
+  #define debugPrint(...)
+#endif
+
+/* END TEST */
+
 class TheThingsNetwork
 {
   private:


### PR DESCRIPTION
Adding debugPrintln and debugPrint to TheThingsNetwork.h to simplify example codes. #4