### PR TITLE
Simplify: call reset in personalize and join

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -202,6 +202,7 @@ bool TheThingsNetwork::enableFsbChannels(int fsb) {
 }
 
 bool TheThingsNetwork::personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]) {
+  TheThingsNetwork::reset();
   sendCommand(F("mac set devaddr"), devAddr, 4);
   sendCommand(F("mac set nwkskey"), nwkSKey, 16);
   sendCommand(F("mac set appskey"), appSKey, 16);
@@ -238,7 +239,7 @@ bool TheThingsNetwork::join(const byte appEui[8], const byte appKey[16]) {
     debugPrintLn(response);
     return false;
   }
-
+  TheThingsNetwork::reset();
   debugPrint(F("Join accepted. Status: "));
   debugPrintLn(readValue(F("mac get status")));
   return true;


### PR DESCRIPTION
Calling reset() in personalize() and join() within the library, no need to call reset() in the exemples. #6