### PR TITLE
simplify: creating setModemSerial() to define Serials and their Baud rate

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -4,6 +4,9 @@
 #include <Arduino.h>
 #include <TheThingsNetwork.h>
 
+#define debugSerial Serial
+#define loraSerial Serial
+
 #define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
 #define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
 
@@ -311,4 +314,20 @@ void TheThingsNetwork::showStatus() {
   debugPrintLn(readValue(F("mac get rxdelay1")));
   debugPrint(F("RX Delay 2: "));
   debugPrintLn(readValue(F("mac get rxdelay2")));
+}
+
+void TheThingsNetwork::setModemSerial(Stream& modemSerial)
+{
+  if (modemSerial.available() == 0)
+    return ;
+}
+
+void TheThingsNetwork::initFor()
+{
+  debugSerial.begin(115200);
+  loraSerial.begin(57600);
+  delay(1000);
+
+  TheThingsNetwork::setModemSerial(loraSerial);
+  TheThingsNetwork::init(loraSerial, debugSerial);
 }


### PR DESCRIPTION
Created initFor(), to simplify examples. Still working on setModemSerial : I need to make sure loraSerial(Serial1) has the right port. #5