### PR TITLE
Set correct duty-cycle(s)

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -327,7 +327,7 @@ void TheThingsNetwork::set_dcycle()
       total_ch += 1;
     str = "";
   }
-  new_dcycle = (100 / total_ch) - 1;
+  new_dcycle = (100 * total_ch) - 1;
   for (ch = 0; ch < total_ch; ch++) {
     str.concat(F("mac set ch dcycle "));
     str.concat(ch);

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -312,3 +312,28 @@ void TheThingsNetwork::showStatus() {
   debugPrint(F("RX Delay 2: "));
   debugPrintLn(readValue(F("mac get rxdelay2")));
 }
+
+void TheThingsNetwork::set_dcycle()
+{
+  int ch;
+  int total_ch = 0;
+  int new_dcycle = 0;
+  String str = "";
+
+  for (ch = 0; ch < 16; ch++) {
+    str.concat(F("mac get ch status "));
+    str.concat(ch);
+    if (readValue(str) == F("on"))
+      total_ch += 1;
+    str = "";
+  }
+  new_dcycle = (100 / total_ch) - 1;
+  for (ch = 0; ch < total_ch; ch++) {
+    str.concat(F("mac set ch dcycle "));
+    str.concat(ch);
+    str.concat(F(" "));
+    str.concat(new_dcycle);
+    sendCommand(str);
+    str = "";
+  }
+}


### PR DESCRIPTION
Created a function called set_dcycle, it sets a new duty-cycle to all active channels after join() function. #21