### PR TITLE
Deliver downlink messages to (callback) function

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -292,14 +292,6 @@ int TheThingsNetwork::onMessage(String response)
     return (1);
 }
 
-int TheThingsNetwork::sendString(String message, int port, bool confirm) {
-  int l = message.length();
-  byte buf[l + 1];
-  message.getBytes(buf, l + 1);
-
-  return sendBytes(buf, l, port, confirm);
-}
-
 void TheThingsNetwork::showStatus() {
   debugPrint(F("EUI: "));
   debugPrintLn(readValue(F("sys get hweui")));

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -251,33 +251,45 @@ int TheThingsNetwork::sendBytes(const byte* buffer, int length, int port, bool c
   str.concat(port);
   if (!sendCommand(str, buffer, length)) {
     debugPrintLn(F("Send command failed"));
-    return 0;
+    return (-1);
   }
 
   String response = readLine(10000);
   if (response == "") {
     debugPrintLn(F("Time-out"));
-    return 0;
+    return (-2);
   }
   if (response == F("mac_tx_ok")) {
     debugPrintLn(F("Successful transmission"));
-    return 0;
+    return (0);
   }
   if (response.startsWith(F("mac_rx"))) {
+    if (TheThingsNetwork::onMessage(response) == 1)
+      return (2);
+    return (1);
+  }
+  debugPrint(F("Unexpected response: "));
+  debugPrintLn(response);
+  return (-3);
+}
+
+int TheThingsNetwork::onMessage(String response)
+{
+   byte downlink[64];
+
+    if (response == "")
+      return (0);
     int portEnds = response.indexOf(" ", 7);
-    this->downlinkPort = response.substring(7, portEnds).toInt();
+    int downlinkPort = response.substring(7, portEnds).toInt();
     String data = response.substring(portEnds + 1);
     int downlinkLength = data.length() / 2;
     for (int i = 0, d = 0; i < downlinkLength; i++, d += 2)
-      this->downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
+       downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
     debugPrint(F("Successful transmission. Received "));
     debugPrint(downlinkLength);
     debugPrintLn(F(" bytes"));
-    return downlinkLength;
-  }
-
-  debugPrint(F("Unexpected response: "));
-  debugPrintLn(response);
+    receiveEvent(downlink, downlinkLength, downlinkPort);
+    return (1);
 }
 
 int TheThingsNetwork::sendString(String message, int port, bool confirm) {

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -47,6 +47,7 @@ class TheThingsNetwork
     bool join(const byte appEui[8], const byte appKey[16]);
     int sendBytes(const byte* buffer, int length, int port = 1, bool confirm = false);
     int sendString(String message, int port = 1, bool confirm = false);
+    int onMessage(string response);
     void showStatus();
 };
 


### PR DESCRIPTION
created onMessage() to clarify sendBytes.
onMessage() contains a buffer downlink and an int downlinkPort to get info on the received message and then send the info to receiveEvent().#23
I couldn't register onMessage() like an event: it needs libraries like <event.h> and <wire.h>, so the user can't choose what to put in onMessage().
I added some (not the right ones) return values for sendBytes.#11