### PR TITLE
defined debugSerialPrint/Ln for Serial and debugPrint/Ln for Stream

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -1,9 +1,12 @@
 // Copyright © 2016 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 
-#define DEBUG 1
+
 #include <Arduino.h>
 #include <TheThingsNetwork.h>
+
+#define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
+#define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
 
 void TheThingsNetwork::init(Stream& modemStream, Stream& debugStream) {
   this->modemStream = &modemStream;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -1,11 +1,9 @@
 // Copyright © 2016 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 
+#define DEBUG 1
 #include <Arduino.h>
 #include <TheThingsNetwork.h>
-
-#define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
-#define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
 
 void TheThingsNetwork::init(Stream& modemStream, Stream& debugStream) {
   this->modemStream = &modemStream;

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -23,6 +23,17 @@
 #define HEX_CHAR_TO_NIBBLE(c) ((c >= 'A') ? (c - 'A' + 0x0A) : (c - '0'))
 #define HEX_PAIR_TO_BYTE(h, l) ((HEX_CHAR_TO_NIBBLE(h) << 4) + HEX_CHAR_TO_NIBBLE(l))
 
+#ifdef DEBUG
+#define debugSerialPrintLn(...) { if (debugSerial) debugSerial.println(__VA_ARGS__); }
+#define debugSerialPrint(...) { if (debugSerial) debugSerial.print(__VA_ARGS__); }
+#define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
+#define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
+#else
+#define debugPrintLn(...)
+#define debugPrint(...)
+#endif
+
+
 class TheThingsNetwork
 {
   private:

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -24,10 +24,8 @@
 #define HEX_PAIR_TO_BYTE(h, l) ((HEX_CHAR_TO_NIBBLE(h) << 4) + HEX_CHAR_TO_NIBBLE(l))
 
 #ifdef DEBUG
-#define debugSerialPrintLn(...) { if (debugSerial) debugSerial.println(__VA_ARGS__); }
-#define debugSerialPrint(...) { if (debugSerial) debugSerial.print(__VA_ARGS__); }
-#define debugPrintLn(...) { if (debugStream) debugStream->println(__VA_ARGS__); }
-#define debugPrint(...) { if (debugStream) debugStream->print(__VA_ARGS__); }
+#define debugPrintLn(...) { if (debugSerial) debugSerial.println(__VA_ARGS__); }
+#define debugPrint(...) { if (debugSerial) debugSerial.print(__VA_ARGS__); }
 #else
 #define debugPrintLn(...)
 #define debugPrint(...)

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -23,15 +23,6 @@
 #define HEX_CHAR_TO_NIBBLE(c) ((c >= 'A') ? (c - 'A' + 0x0A) : (c - '0'))
 #define HEX_PAIR_TO_BYTE(h, l) ((HEX_CHAR_TO_NIBBLE(h) << 4) + HEX_CHAR_TO_NIBBLE(l))
 
-#ifdef DEBUG
-#define debugPrintLn(...) { if (debugSerial) debugSerial.println(__VA_ARGS__); }
-#define debugPrint(...) { if (debugSerial) debugSerial.print(__VA_ARGS__); }
-#else
-#define debugPrintLn(...)
-#define debugPrint(...)
-#endif
-
-
 class TheThingsNetwork
 {
   private:


### PR DESCRIPTION
to avoid warnings while compilating so in examples use debugSerialPrint/Ln and debugPrint/Ln in library.
You have to: #define DEBUG 1 in examples #4