### PR TITLE
Add onMessage to set callback for downlink messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ TheThingsNetwork class features the following [public methods](https://github.co
 
 ```C++
   public:
-    int downlinkPort;
-    byte downlink[64];
     void init(Stream& modemStream, Stream& debugStream);
+    void onMessage(void (*cb)(const byte* buffer, int length, int port));
     void reset(bool adr = true, int sf = DEFAULT_SF, int fsb = DEFAULT_FSB);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool join(const byte appEui[8], const byte appKey[16]);

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,11 +18,9 @@ debugPrint				KEYWORD2
 HEX_CHAR_TO_NIBBLE		KEYWORD2
 HEX_PAIR_TO_BYTE		KEYWORD2
 
-downlinkPort			KEYWORD2
-downlink				KEYWORD2
-
 init					KEYWORD2
 reset					KEYWORD2
+onMessage				KEYWORD2
 personalize				KEYWORD2
 join					KEYWORD2
 sendBytes				KEYWORD2

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -269,13 +269,13 @@ int TheThingsNetwork::sendBytes(const byte* buffer, int length, int port, bool c
     return 0;
   }
   if (response.startsWith(F("mac_rx"))) {
-    byte downlink[64];
     int portEnds = response.indexOf(" ", 7);
     int downlinkPort = response.substring(7, portEnds).toInt();
     String data = response.substring(portEnds + 1);
     int downlinkLength = data.length() / 2;
+    byte downlink[64];
     for (int i = 0, d = 0; i < downlinkLength; i++, d += 2)
-       downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
+      downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
     debugPrint(F("Successful transmission. Received "));
     debugPrint(downlinkLength);
     debugPrintLn(F(" bytes"));

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -201,6 +201,11 @@ bool TheThingsNetwork::enableFsbChannels(int fsb) {
   return true;
 }
 
+void TheThingsNetwork::onMessage(void (*cb)(const byte* buffer, int length, int port))
+{
+  this->messageCallback = cb;
+}
+
 bool TheThingsNetwork::personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]) {
   sendCommand(F("mac set devaddr"), devAddr, 4);
   sendCommand(F("mac set nwkskey"), nwkSKey, 16);
@@ -264,15 +269,18 @@ int TheThingsNetwork::sendBytes(const byte* buffer, int length, int port, bool c
     return 0;
   }
   if (response.startsWith(F("mac_rx"))) {
+    byte downlink[64];
     int portEnds = response.indexOf(" ", 7);
-    this->downlinkPort = response.substring(7, portEnds).toInt();
+    int downlinkPort = response.substring(7, portEnds).toInt();
     String data = response.substring(portEnds + 1);
     int downlinkLength = data.length() / 2;
     for (int i = 0, d = 0; i < downlinkLength; i++, d += 2)
-      this->downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
+       downlink[i] = HEX_PAIR_TO_BYTE(data[d], data[d+1]);
     debugPrint(F("Successful transmission. Received "));
     debugPrint(downlinkLength);
     debugPrintLn(F(" bytes"));
+    if (this->messageCallback)
+      this->messageCallback(downlink, downlinkLength, downlinkPort);
     return downlinkLength;
   }
 

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -29,6 +29,7 @@ class TheThingsNetwork
     Stream* modemStream;
     Stream* debugStream;
     String model;
+    void (* messageCallback)(const byte* buffer, int length, int port);
 
     String readLine(int waitTime = DEFAULT_WAIT_TIME);
     bool waitForOK(int waitTime = DEFAULT_WAIT_TIME, String okMessage = "ok");
@@ -42,6 +43,7 @@ class TheThingsNetwork
     int downlinkPort;
     byte downlink[64];
     void init(Stream& modemStream, Stream& debugStream);
+    void onMessage(void (*cb)(const byte* buffer, int length, int port));
     void reset(bool adr = true, int sf = DEFAULT_SF, int fsb = DEFAULT_FSB);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool join(const byte appEui[8], const byte appKey[16]);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -40,8 +40,6 @@ class TheThingsNetwork
     bool enableFsbChannels(int fsb);
 
   public:
-    int downlinkPort;
-    byte downlink[64];
     void init(Stream& modemStream, Stream& debugStream);
     void onMessage(void (*cb)(const byte* buffer, int length, int port));
     void reset(bool adr = true, int sf = DEFAULT_SF, int fsb = DEFAULT_FSB);


### PR DESCRIPTION
This fixes #23 in a more clean way than #34 by letting the user set a callback to receive downlink messages.

*Note:* For now, this doesn't touch the return value, which could now become success/error codes as requested in #11, for which #37 is pending.

In `setup()` set the callback:

```c
void setup() {
  // ..
  ttn.onMessage(message);
  // ..
}
```

Elsewhere in your sketch define `message` or whatever you call it:

```c
void message(const byte* buffer, int length, int port)
{
  debugPrint("Receive " + String(length) + " bytes on port " + String(port) + ": ");
  for (int i = 0; i < length; i++)
    debugPrint(String(buffer[i]) + " ");
  debugPrintLn();
}
```