### PR TITLE
debugPrint > debugPrintLn

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -297,7 +297,7 @@ void TheThingsNetwork::showStatus() {
   debugPrint(F("EUI: "));
   debugPrintLn(readValue(F("sys get hweui")));
   debugPrint(F("Battery: "));
-  debugPrint(readValue(F("sys get vdd")));
+  debugPrintLn(readValue(F("sys get vdd")));
   debugPrint(F("AppEUI: "));
   debugPrintLn(readValue(F("mac get appeui")));
   debugPrint(F("DevEUI: "));


### PR DESCRIPTION
Fix:

```
EUI: 0004A30B001B7AD2
Battery: 3213AppEUI: 70B3D57EF0000028
DevEUI: 0004A30B001B7AD2
DevAddr: 260125CD
Data Rate: 5
RX Delay 1: 1000
RX Delay 2: 2000
```