### PR TITLE
Added SoftwareSerial listen function

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -67,6 +67,10 @@ char btohexa_low(unsigned char b) {
 }
 
 bool TheThingsNetwork::sendCommand(String cmd, const byte *buf, int length, int waitTime) {
+
+  // listen if softwareserial is used
+  if(softser){softser->listen();}
+
   debugPrint(F("Sending: "));
   debugPrint(cmd);
   debugPrint(F(" with "));
@@ -88,6 +92,9 @@ void TheThingsNetwork::reset(bool adr) {
   #if !TTN_ADR_SUPPORTED
     adr = false;
   #endif
+
+  // listen if softwareserial is used
+  if(softser){softser->listen();}
 
   modemStream->println(F("sys reset"));
   String version = readLine(3000);
@@ -397,14 +404,25 @@ void TheThingsNetwork::configureChannels(int sf, int fsb) {
       configureUS915(sf, fsb);
       break;
     default:
-      debugPrintLn("Invalid frequency plan");
+      debugPrintLn(F("Invalid frequency plan"));
       break;
   }
 }
 
-TheThingsNetwork::TheThingsNetwork(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf, int fsb) {
+//Added HardwareSerial and SoftwareSerial support
+
+TheThingsNetwork::TheThingsNetwork(HardwareSerial& modemStream, Stream& debugStream, fp_ttn_t fp, int sf, int fsb) {
   this->debugStream = &debugStream;
   this->modemStream = &modemStream;
+  this->fp = fp;
+  this->sf = sf;
+  this->fsb = fsb;
+}
+
+TheThingsNetwork::TheThingsNetwork(SoftwareSerial& modemStream, Stream& debugStream, fp_ttn_t fp, int sf, int fsb) {
+  this->debugStream = &debugStream;
+  this->modemStream = &modemStream;
+  softser = &modemStream;
   this->fp = fp;
   this->sf = sf;
   this->fsb = fsb;

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -5,6 +5,7 @@
 #define _THETHINGSNETWORK_H_
 
 #include <Arduino.h>
+#include <SoftwareSerial.h>
 #include <Stream.h>
 
 #define TTN_DEFAULT_WAIT_TIME 120
@@ -33,6 +34,8 @@ class TheThingsNetwork
   private:
     Stream* modemStream;
     Stream* debugStream;
+    // added softser support
+    SoftwareSerial* softser = NULL;
     String model;
     fp_ttn_t fp;
     int sf;
@@ -51,7 +54,9 @@ class TheThingsNetwork
     void configureChannels(int sf, int fsb);
 
   public:
-    TheThingsNetwork(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB); 
+    /*TheThingsNetwork(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB); */
+    TheThingsNetwork(HardwareSerial& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB);
+    TheThingsNetwork(SoftwareSerial& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB);
     void showStatus();
     void onMessage(void (*cb)(const byte* payload, int length, int port));
     bool provision(const byte appEui[8], const byte appKey[16]);


### PR DESCRIPTION
I tweaked the library a bit to enable listen function if users use this library for SoftwareSerial case. In original library, SoftwareSerial can be used but if the user use another SoftwareSerial class in the same sketch, the library might not work. In this tweaked library, I added some lines to check if user uses modemStream as HardwareSerial or SoftwareSerial, if SoftwareSerial, modemStream will intend to listen every time before sendCommand function is executed.
