### PR TITLE
Remove time out, fixes #90

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -18,10 +18,6 @@ String TheThingsNetwork::readLine() {
 
 bool TheThingsNetwork::waitForOK(String okMessage) {
   String line = readLine();
-  if (line == "") {
-    debugPrintLn(F("Wait for OK time-out expired"));
-    return false;
-  }
 
   if (line != okMessage) {
     debugPrint(F("Response is not OK: "));
@@ -91,11 +87,6 @@ void TheThingsNetwork::reset(bool adr) {
 
   modemStream->println(F("sys reset"));
   String version = readLine();
-  if (version == "") {
-    debugPrintLn(F("Invalid version"));
-    return;
-  }
-  
   model = version.substring(0, version.indexOf(' '));
   debugPrint(F("Version is "));
   debugPrint(version);
@@ -205,10 +196,6 @@ int TheThingsNetwork::sendBytes(const byte* payload, int length, int port, bool 
   }
 
   String response = readLine();
-  if (response == "") {
-    debugPrintLn(F("Time-out"));
-    return -2;
-  }
   if (response == F("mac_tx_ok")) {
     debugPrintLn(F("Successful transmission"));
     return 1;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -85,8 +85,7 @@ void TheThingsNetwork::reset(bool adr) {
 
   clearBuffer();
 
-  modemStream->println(F("sys reset"));
-  String version = readLine();
+  String version = readValue(F("sys reset"));
   model = version.substring(0, version.indexOf(' '));
   debugPrint(F("Version is "));
   debugPrint(version);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -39,7 +39,6 @@ class TheThingsNetwork
     void (* messageCallback)(const byte* payload, int length, int port);
    
     String readLine();
-    bool waitForOK(String okMessage = "ok");
     String readValue(String key);
     bool sendCommand(String cmd);
     bool sendCommand(String cmd, String value);
@@ -48,7 +47,6 @@ class TheThingsNetwork
     void configureEU868(int sf);
     void configureUS915(int sf, int fsb);
     void configureChannels(int sf, int fsb);
-    void clearBuffer();
 
   public:
     TheThingsNetwork(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB); 

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -7,7 +7,6 @@
 #include <Arduino.h>
 #include <Stream.h>
 
-#define TTN_DEFAULT_WAIT_TIME 120
 #define TTN_DEFAULT_SF 7
 #define TTN_DEFAULT_FSB 2
 
@@ -39,12 +38,12 @@ class TheThingsNetwork
     int fsb;
     void (* messageCallback)(const byte* payload, int length, int port);
    
-    String readLine(int waitTime = TTN_DEFAULT_WAIT_TIME);
-    bool waitForOK(int waitTime = TTN_DEFAULT_WAIT_TIME, String okMessage = "ok");
+    String readLine();
+    bool waitForOK(String okMessage = "ok");
     String readValue(String key);
-    bool sendCommand(String cmd, int waitTime = TTN_DEFAULT_WAIT_TIME);
-    bool sendCommand(String cmd, String value, int waitTime = TTN_DEFAULT_WAIT_TIME);
-    bool sendCommand(String cmd, const byte* buf, int length, int waitTime = TTN_DEFAULT_WAIT_TIME);
+    bool sendCommand(String cmd);
+    bool sendCommand(String cmd, String value);
+    bool sendCommand(String cmd, const byte* buf, int length);
     void reset(bool adr = true);
     void configureEU868(int sf);
     void configureUS915(int sf, int fsb);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -48,6 +48,7 @@ class TheThingsNetwork
     void configureEU868(int sf);
     void configureUS915(int sf, int fsb);
     void configureChannels(int sf, int fsb);
+    void clearBuffer();
 
   public:
     TheThingsNetwork(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB); 


### PR DESCRIPTION
This fixes #90, but... I now get an empty response when I send:

```
-- LOOP
Sending: mac tx uncnf 1 with 1 bytes
Time-out
```

Any idea @johanstokking?