### PR TITLE
Optimize types with a specific bit-size

### DIFF
--- a/API.md
+++ b/API.md
@@ -6,14 +6,14 @@ Include and instantiate the TheThingsNetwork class. The constructor initialize t
 ```c
 #include <TheThingsNetwork.h>
 
-TheThingsNetwork ttn(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int sf = 7, int fsb = 2);
+TheThingsNetwork ttn(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int8_t sf = 7, int8_t fsb = 2);
 ```
 
 - `Stream& modemStream`: Stream for the LoRa modem (for The Things Node/Uno use `Serial1` and data rate `57600`).
 - `Stream& debugStream`: Stream to write debug logs to (for The Things Node/Uno use `Serial` and data rate `9600`).
 - `fp_ttn_fp fp`: The frequency plan: `TTN_FP_EU868` or `TTN_FP_US915` depending on the region you deploy in.
-- `int sf = 7`: Optional custom spreading factor. Can be `7` to `12` for `TTN_FP_EU868` and `7` to `12` for `TTN_FP_US915`. Defaults to `7`.
-- `int fsb = 2`: Optional custom front-side bus. Can be `1` to `8`. Defaults to `2`.
+- `int8_t sf = 7`: Optional custom spreading factor. Can be `7` to `12` for `TTN_FP_EU868` and `7` to `12` for `TTN_FP_US915`. Defaults to `7`.
+- `int8_t fsb = 2`: Optional custom front-side bus. Can be `1` to `8`. Defaults to `2`.
 
 ## Method: showStatus
 Writes information about the device and LoRa module to `debugStream`.
@@ -42,12 +42,12 @@ See the [DeviceInfo](https://github.com/TheThingsNetwork/arduino-device-lib/blob
 Sets a function which will be called to process incoming messages.
 
 ```c
-void onMessage(void (*cb)(const byte* payload, int length, int port));
+void onMessage(void (*cb)(const byte* payload, size_t length, int8_t port));
 ```
 
 - `const byte* payload`: Bytes received.
-- `int length`: Number of bytes.
-- `int port`: The port addressed.
+- `size_t length`: Number of bytes.
+- `int8_t port`: The port addressed.
 
 See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/Receive/Receive.ino) example.
 
@@ -55,14 +55,14 @@ See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/ma
 Activate the device via OTAA (default).
 
 ```c
-bool join(const byte appEui[8], const byte appKey[16], int retries = -1, long int retryDelay = 10000);
-bool join(int retries = -1, long int retryDelay = 10000);
+bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, int32_t retryDelay = 10000);
+bool join(int8_t retries = -1, int32_t retryDelay = 10000);
 ```
 
 - `const byte appEui[8]`: Application EUI the device is registered to.
 - `const byte appKey[16]`: Application Key assigned to the device.
-- `int retries = -1`: Number of times to retry after failed or unconfirmed join. Defaults to `-1` which means infinite.
-- `long int retryDelay = 10000`: Delay in ms between attempts. Defaults to 10 seconds.
+- `int8_t retries = -1`: Number of times to retry after failed or unconfirmed join. Defaults to `-1` which means infinite.
+- `int32_t retryDelay = 10000`: Delay in ms between attempts. Defaults to 10 seconds.
 
 Returns `true` or `false` depending on whether it received confirmation that the activation was successful before the maximum number of attempts.
 
@@ -90,21 +90,21 @@ See the [ABP](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master
 Send a message to the application using raw bytes.
 
 ```c
-int sendBytes(const byte* payload, int length, int port = 1, bool confirm = false);
+int sendBytes(const byte* payload, size_t length, int8_t port = 1, bool confirm = false);
 ```
 
 - `const byte* payload `: Bytes to send.
-- `int length`: The number of bytes. Use `sizeof(payload)` to get it.
-- `int port = 1`: The port to address. Defaults to `1`.
+- `size_t length`: The number of bytes. Use `sizeof(payload)` to get it.
+- `int8_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation. Defaults to `false`.
 
-Returns a success or error code and logs the related error message: 
+Returns a success or error code and logs the related error message:
 
 * `-1`: Send command failed.
 * `-2`: Time-out.
 * `1`: Successful transmission.
 * `2`: Successful transmission. Received \<N> bytes
-* `-10`: Unexpected response: \<Response> 
+* `-10`: Unexpected response: \<Response>
 
 See the [Send](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/Send/Send.ino) example.
 
@@ -113,7 +113,7 @@ Also in sendBytes, due to TTN's 30 second fair access policy, we update the airt
 ## Method: poll
 Calls `sendBytes()` with `{ 0x00 }` as payload to poll for incoming messages.
 
-- `int port = 1`: The port to address. Defaults to `1`.
+- `int8_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation.
 
 Returns the result of `sendBytes()`.
@@ -124,7 +124,7 @@ See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/ma
 Sets the information needed to activate the device via OTAA, without actually activating. Call join() without the first 2 arguments to activate.
 
 ```c
-bool provision(const byte appEui[8], const appKey[16]);
+bool provision(const byte appEui[8], const byte appKey[16]);
 ```
 
 - `const byte appEui[8]`: Application Identifier for the device.

--- a/API.md
+++ b/API.md
@@ -42,12 +42,12 @@ See the [DeviceInfo](https://github.com/TheThingsNetwork/arduino-device-lib/blob
 Sets a function which will be called to process incoming messages.
 
 ```c
-void onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port));
+void onMessage(void (*cb)(const byte* payload, size_t length, port_t port));
 ```
 
 - `const byte* payload`: Bytes received.
 - `size_t length`: Number of bytes.
-- `uint8_t port`: The port addressed.
+- `port_t port`: The port addressed.
 
 See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/Receive/Receive.ino) example.
 
@@ -90,12 +90,12 @@ See the [ABP](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master
 Send a message to the application using raw bytes.
 
 ```c
-int sendBytes(const byte* payload, size_t length, uint8_t port = 1, bool confirm = false);
+int sendBytes(const byte* payload, size_t length, port_t port = 1, bool confirm = false);
 ```
 
 - `const byte* payload `: Bytes to send.
 - `size_t length`: The number of bytes. Use `sizeof(payload)` to get it.
-- `uint8_t port = 1`: The port to address. Defaults to `1`.
+- `port_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation. Defaults to `false`.
 
 Returns a success or error code and logs the related error message:
@@ -113,7 +113,7 @@ Also in sendBytes, due to TTN's 30 second fair access policy, we update the airt
 ## Method: poll
 Calls `sendBytes()` with `{ 0x00 }` as payload to poll for incoming messages.
 
-- `uint8_t port = 1`: The port to address. Defaults to `1`.
+- `port_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation.
 
 Returns the result of `sendBytes()`.

--- a/API.md
+++ b/API.md
@@ -6,14 +6,14 @@ Include and instantiate the TheThingsNetwork class. The constructor initialize t
 ```c
 #include <TheThingsNetwork.h>
 
-TheThingsNetwork ttn(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, int8_t sf = 7, int8_t fsb = 2);
+TheThingsNetwork ttn(Stream& modemStream, Stream& debugStream, fp_ttn_t fp, uint8_t sf = 7, uint8_t fsb = 2);
 ```
 
 - `Stream& modemStream`: Stream for the LoRa modem (for The Things Node/Uno use `Serial1` and data rate `57600`).
 - `Stream& debugStream`: Stream to write debug logs to (for The Things Node/Uno use `Serial` and data rate `9600`).
 - `fp_ttn_fp fp`: The frequency plan: `TTN_FP_EU868` or `TTN_FP_US915` depending on the region you deploy in.
-- `int8_t sf = 7`: Optional custom spreading factor. Can be `7` to `12` for `TTN_FP_EU868` and `7` to `12` for `TTN_FP_US915`. Defaults to `7`.
-- `int8_t fsb = 2`: Optional custom front-side bus. Can be `1` to `8`. Defaults to `2`.
+- `uint8_t sf = 7`: Optional custom spreading factor. Can be `7` to `12` for `TTN_FP_EU868` and `7` to `12` for `TTN_FP_US915`. Defaults to `7`.
+- `uint8_t fsb = 2`: Optional custom front-side bus. Can be `1` to `8`. Defaults to `2`.
 
 ## Method: showStatus
 Writes information about the device and LoRa module to `debugStream`.
@@ -42,12 +42,12 @@ See the [DeviceInfo](https://github.com/TheThingsNetwork/arduino-device-lib/blob
 Sets a function which will be called to process incoming messages.
 
 ```c
-void onMessage(void (*cb)(const byte* payload, size_t length, int8_t port));
+void onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port));
 ```
 
 - `const byte* payload`: Bytes received.
 - `size_t length`: Number of bytes.
-- `int8_t port`: The port addressed.
+- `uint8_t port`: The port addressed.
 
 See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/Receive/Receive.ino) example.
 
@@ -55,14 +55,14 @@ See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/ma
 Activate the device via OTAA (default).
 
 ```c
-bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, int32_t retryDelay = 10000);
-bool join(int8_t retries = -1, int32_t retryDelay = 10000);
+bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, uint32_t retryDelay = 10000);
+bool join(int8_t retries = -1, uint32_t retryDelay = 10000);
 ```
 
 - `const byte appEui[8]`: Application EUI the device is registered to.
 - `const byte appKey[16]`: Application Key assigned to the device.
 - `int8_t retries = -1`: Number of times to retry after failed or unconfirmed join. Defaults to `-1` which means infinite.
-- `int32_t retryDelay = 10000`: Delay in ms between attempts. Defaults to 10 seconds.
+- `uint32_t retryDelay = 10000`: Delay in ms between attempts. Defaults to 10 seconds.
 
 Returns `true` or `false` depending on whether it received confirmation that the activation was successful before the maximum number of attempts.
 
@@ -90,12 +90,12 @@ See the [ABP](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master
 Send a message to the application using raw bytes.
 
 ```c
-int sendBytes(const byte* payload, size_t length, int8_t port = 1, bool confirm = false);
+int sendBytes(const byte* payload, size_t length, uint8_t port = 1, bool confirm = false);
 ```
 
 - `const byte* payload `: Bytes to send.
 - `size_t length`: The number of bytes. Use `sizeof(payload)` to get it.
-- `int8_t port = 1`: The port to address. Defaults to `1`.
+- `uint8_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation. Defaults to `false`.
 
 Returns a success or error code and logs the related error message:
@@ -113,7 +113,7 @@ Also in sendBytes, due to TTN's 30 second fair access policy, we update the airt
 ## Method: poll
 Calls `sendBytes()` with `{ 0x00 }` as payload to poll for incoming messages.
 
-- `int8_t port = 1`: The port to address. Defaults to `1`.
+- `uint8_t port = 1`: The port to address. Defaults to `1`.
 - `bool confirm = false`: Whether to ask for confirmation.
 
 Returns the result of `sendBytes()`.

--- a/examples/QuickStart/QuickStart.ino
+++ b/examples/QuickStart/QuickStart.ino
@@ -39,7 +39,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, size_t length, int8_t port) {
+void message(const byte* payload, size_t length, uint8_t port) {
   debugSerial.println("-- MESSAGE");
 
   // Only handle messages of a single byte

--- a/examples/QuickStart/QuickStart.ino
+++ b/examples/QuickStart/QuickStart.ino
@@ -39,7 +39,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, int length, int port) {
+void message(const byte* payload, size_t length, int8_t port) {
   debugSerial.println("-- MESSAGE");
 
   // Only handle messages of a single byte
@@ -50,7 +50,7 @@ void message(const byte* payload, int length, int port) {
   if (payload[0] == 0) {
     debugSerial.println("LED: off");
     digitalWrite(LED_BUILTIN, LOW);
-      
+
   } else if (payload[0] == 1) {
     debugSerial.println("LED: on");
     digitalWrite(LED_BUILTIN, HIGH);

--- a/examples/QuickStart/QuickStart.ino
+++ b/examples/QuickStart/QuickStart.ino
@@ -39,7 +39,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, size_t length, uint8_t port) {
+void message(const byte* payload, size_t length, port_t port) {
   debugSerial.println("-- MESSAGE");
 
   // Only handle messages of a single byte

--- a/examples/Receive/Receive.ino
+++ b/examples/Receive/Receive.ino
@@ -35,7 +35,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, int length, int port) {
+void message(const byte* payload, size_t length, int8_t port) {
   debugSerial.println("-- MESSAGE");
   debugSerial.print("Received " + String(length) + " bytes on port " + String(port) + ":");
 

--- a/examples/Receive/Receive.ino
+++ b/examples/Receive/Receive.ino
@@ -35,7 +35,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, size_t length, int8_t port) {
+void message(const byte* payload, size_t length, uint8_t port) {
   debugSerial.println("-- MESSAGE");
   debugSerial.print("Received " + String(length) + " bytes on port " + String(port) + ":");
 

--- a/examples/Receive/Receive.ino
+++ b/examples/Receive/Receive.ino
@@ -35,7 +35,7 @@ void loop() {
   delay(10000);
 }
 
-void message(const byte* payload, size_t length, uint8_t port) {
+void message(const byte* payload, size_t length, port_t port) {
   debugSerial.println("-- MESSAGE");
   debugSerial.print("Received " + String(length) + " bytes on port " + String(port) + ":");
 

--- a/examples/Workshop/Workshop.ino
+++ b/examples/Workshop/Workshop.ino
@@ -38,7 +38,7 @@ void setup() {
 }
 
 void loop() {
-  // Create a buffer with three bytes  
+  // Create a buffer with three bytes
   byte payload[3] = { 0x01, 0x02, 0x03 };
 
   // Send it to the network

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -257,7 +257,7 @@ void TheThingsNetwork::trackAirtime(size_t payloadSize) {
 
   float Tsym = pow(2, this->info.sf) / this->info.band;
   float Tpreamble = (this->info.ps + 4.25) * Tsym;
-  unsigned int32_t payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
+  int16_t payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
   float Tpayload = payLoadSymbNb * Tsym;
   float Tpacket = Tpreamble + Tpayload;
   this->airtime = this->airtime + (Tpacket / 1000);

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -64,7 +64,7 @@ char btohexa_low(unsigned char b) {
 bool TheThingsNetwork::sendCommand(String cmd, const byte *buf, size_t length) {
   String str = cmd + " ";
 
-  for (int i = 0; i < length; i++) {
+  for (int32_t i = 0; i < length; i++) {
     str += btohexa_high(buf[i]);
     str += btohexa_low(buf[i]);
   }
@@ -198,7 +198,7 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, int8_t port,
     String data = response.substring(portEnds + 1);
     size_t downlinkLength = data.length() / 2;
     byte downlink[64];
-    for (int i = 0, d = 0; i < downlinkLength; i++, d += 2) {
+    for (int32_t i = 0, d = 0; i < downlinkLength; i++, d += 2) {
       downlink[i] = TTN_HEX_PAIR_TO_BYTE(data[d], data[d+1]);
     }
     debugPrint(F("Successful transmission. Received "));
@@ -227,7 +227,7 @@ void TheThingsNetwork::fillAirtimeInfo() {
   this->info.cr = 0;
   this->info.de = 0;
 
-  int32_t i;
+  int16_t i;
   String message = readValue(F("radio get sf"));
   for (i = 2; message[i] && i <= 3; i++) {
     this->info.sf = (this->info.sf + message[i] - 48) * 10;
@@ -257,7 +257,7 @@ void TheThingsNetwork::trackAirtime(size_t payloadSize) {
 
   float Tsym = pow(2, this->info.sf) / this->info.band;
   float Tpreamble = (this->info.ps + 4.25) * Tsym;
-  unsigned int payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
+  unsigned int32_t payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
   float Tpayload = payLoadSymbNb * Tsym;
   float Tpacket = Tpreamble + Tpayload;
   this->airtime = this->airtime + (Tpacket / 1000);
@@ -290,7 +290,7 @@ void TheThingsNetwork::showStatus() {
 
 void TheThingsNetwork::configureEU868(int8_t sf) {
   int8_t ch;
-  int dr = -1;
+  int8_t dr = -1;
   int32_t freq = 867100000;
   String str = "";
 
@@ -362,7 +362,7 @@ void TheThingsNetwork::configureEU868(int8_t sf) {
 
 void TheThingsNetwork::configureUS915(int8_t sf, int8_t fsb) {
   int8_t ch;
-  int dr = -1;
+  int8_t dr = -1;
   String str = "";
   int8_t chLow = fsb > 0 ? (fsb - 1) * 8 : 0;
   int8_t chHigh = fsb > 0 ? chLow + 7 : 71;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -64,7 +64,7 @@ char btohexa_low(unsigned char b) {
 bool TheThingsNetwork::sendCommand(String cmd, const byte *buf, size_t length) {
   String str = cmd + " ";
 
-  for (int32_t i = 0; i < length; i++) {
+  for (size_t i = 0; i < length; i++) {
     str += btohexa_high(buf[i]);
     str += btohexa_low(buf[i]);
   }
@@ -198,7 +198,7 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, int8_t port,
     String data = response.substring(portEnds + 1);
     size_t downlinkLength = data.length() / 2;
     byte downlink[64];
-    for (int32_t i = 0, d = 0; i < downlinkLength; i++, d += 2) {
+    for (size_t i = 0, d = 0; i < downlinkLength; i++, d += 2) {
       downlink[i] = TTN_HEX_PAIR_TO_BYTE(data[d], data[d+1]);
     }
     debugPrint(F("Successful transmission. Received "));

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -96,7 +96,7 @@ void TheThingsNetwork::reset(bool adr) {
   sendCommand(str);
 }
 
-void TheThingsNetwork::onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port)) {
+void TheThingsNetwork::onMessage(void (*cb)(const byte* payload, size_t length, port_t port)) {
   this->messageCallback = cb;
 }
 
@@ -169,7 +169,7 @@ bool TheThingsNetwork::join(const byte appEui[8], const byte appKey[16], int8_t 
   return join(retries, retryDelay);
 }
 
-int TheThingsNetwork::sendBytes(const byte* payload, size_t length, uint8_t port, bool confirm) {
+int TheThingsNetwork::sendBytes(const byte* payload, size_t length, port_t port, bool confirm) {
   String str = "";
   str.concat(F("mac tx "));
   str.concat(confirm ? F("cnf ") : F("uncnf "));
@@ -194,7 +194,7 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, uint8_t port
   }
   if (response.startsWith(F("mac_rx"))) {
     uint8_t portEnds = response.indexOf(" ", 7);
-    uint8_t downlinkPort = response.substring(7, portEnds).toInt();
+    port_t downlinkPort = response.substring(7, portEnds).toInt();
     String data = response.substring(portEnds + 1);
     size_t downlinkLength = data.length() / 2;
     byte downlink[64];
@@ -214,7 +214,7 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, uint8_t port
   return -10;
 }
 
-int TheThingsNetwork::poll(uint8_t port, bool confirm) {
+int TheThingsNetwork::poll(port_t port, bool confirm) {
   byte payload[] = { 0x00 };
   return sendBytes(payload, 1, port, confirm);
 }

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -96,7 +96,7 @@ void TheThingsNetwork::reset(bool adr) {
   sendCommand(str);
 }
 
-void TheThingsNetwork::onMessage(void (*cb)(const byte* payload, size_t length, int8_t port)) {
+void TheThingsNetwork::onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port)) {
   this->messageCallback = cb;
 }
 
@@ -130,7 +130,7 @@ bool TheThingsNetwork::provision(const byte appEui[8], const byte appKey[16]) {
   return sendCommand(F("mac save"));
 }
 
-bool TheThingsNetwork::join(int8_t retries, int32_t retryDelay) {
+bool TheThingsNetwork::join(int8_t retries, uint32_t retryDelay) {
   configureChannels(this->sf, this->fsb);
   String devEui = readValue(F("sys get hweui"));
   String str = "";
@@ -163,13 +163,13 @@ bool TheThingsNetwork::join(int8_t retries, int32_t retryDelay) {
   return false;
 }
 
-bool TheThingsNetwork::join(const byte appEui[8], const byte appKey[16], int8_t retries, int32_t retryDelay) {
+bool TheThingsNetwork::join(const byte appEui[8], const byte appKey[16], int8_t retries, uint32_t retryDelay) {
   reset();
   provision(appEui, appKey);
   return join(retries, retryDelay);
 }
 
-int TheThingsNetwork::sendBytes(const byte* payload, size_t length, int8_t port, bool confirm) {
+int TheThingsNetwork::sendBytes(const byte* payload, size_t length, uint8_t port, bool confirm) {
   String str = "";
   str.concat(F("mac tx "));
   str.concat(confirm ? F("cnf ") : F("uncnf "));
@@ -193,8 +193,8 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, int8_t port,
     return 1;
   }
   if (response.startsWith(F("mac_rx"))) {
-    int8_t portEnds = response.indexOf(" ", 7);
-    int8_t downlinkPort = response.substring(7, portEnds).toInt();
+    uint8_t portEnds = response.indexOf(" ", 7);
+    uint8_t downlinkPort = response.substring(7, portEnds).toInt();
     String data = response.substring(portEnds + 1);
     size_t downlinkLength = data.length() / 2;
     byte downlink[64];
@@ -214,7 +214,7 @@ int TheThingsNetwork::sendBytes(const byte* payload, size_t length, int8_t port,
   return -10;
 }
 
-int TheThingsNetwork::poll(int8_t port, bool confirm) {
+int TheThingsNetwork::poll(uint8_t port, bool confirm) {
   byte payload[] = { 0x00 };
   return sendBytes(payload, 1, port, confirm);
 }
@@ -227,7 +227,7 @@ void TheThingsNetwork::fillAirtimeInfo() {
   this->info.cr = 0;
   this->info.de = 0;
 
-  int16_t i;
+  uint8_t i;
   String message = readValue(F("radio get sf"));
   for (i = 2; message[i] && i <= 3; i++) {
     this->info.sf = (this->info.sf + message[i] - 48) * 10;
@@ -257,7 +257,7 @@ void TheThingsNetwork::trackAirtime(size_t payloadSize) {
 
   float Tsym = pow(2, this->info.sf) / this->info.band;
   float Tpreamble = (this->info.ps + 4.25) * Tsym;
-  int16_t payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
+  uint16_t payLoadSymbNb = 8 + (max(ceil((8 * payloadSize - 4 * this->info.sf + 28 + 16 - 20 * this->info.header) / (4 * (this->info.sf - 2 * this->info.de))) * (this->info.cr + 4), 0));
   float Tpayload = payLoadSymbNb * Tsym;
   float Tpacket = Tpreamble + Tpayload;
   this->airtime = this->airtime + (Tpacket / 1000);
@@ -288,10 +288,10 @@ void TheThingsNetwork::showStatus() {
   debugPrintLn(F(" s"));
 }
 
-void TheThingsNetwork::configureEU868(int8_t sf) {
-  int8_t ch;
+void TheThingsNetwork::configureEU868(uint8_t sf) {
+  uint8_t ch;
   int8_t dr = -1;
-  int32_t freq = 867100000;
+  uint32_t freq = 867100000;
   String str = "";
 
   str.concat(F("mac set rx2 3 869525000"));
@@ -360,13 +360,13 @@ void TheThingsNetwork::configureEU868(int8_t sf) {
   }
 }
 
-void TheThingsNetwork::configureUS915(int8_t sf, int8_t fsb) {
-  int8_t ch;
+void TheThingsNetwork::configureUS915(uint8_t sf, uint8_t fsb) {
+  uint8_t ch;
   int8_t dr = -1;
   String str = "";
-  int8_t chLow = fsb > 0 ? (fsb - 1) * 8 : 0;
-  int8_t chHigh = fsb > 0 ? chLow + 7 : 71;
-  int8_t ch500 = fsb + 63;
+  uint8_t chLow = fsb > 0 ? (fsb - 1) * 8 : 0;
+  uint8_t chHigh = fsb > 0 ? chLow + 7 : 71;
+  uint8_t ch500 = fsb + 63;
 
   sendCommand(F("radio set freq 904200000"));
   str = "";
@@ -419,7 +419,7 @@ void TheThingsNetwork::configureUS915(int8_t sf, int8_t fsb) {
   }
 }
 
-void TheThingsNetwork::configureChannels(int8_t sf, int8_t fsb) {
+void TheThingsNetwork::configureChannels(uint8_t sf, uint8_t fsb) {
   switch (this->fp) {
     case TTN_FP_EU868:
       configureEU868(sf);
@@ -437,7 +437,7 @@ void TheThingsNetwork::configureChannels(int8_t sf, int8_t fsb) {
   sendCommand(retries);
 }
 
-TheThingsNetwork::TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, int8_t sf, int8_t fsb) {
+TheThingsNetwork::TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, uint8_t sf, uint8_t fsb) {
   this->debugStream = &debugStream;
   this->modemStream = &modemStream;
   this->fp = fp;

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -21,12 +21,12 @@ enum ttn_fp_t {
 
 typedef struct  airtime_s
 {
-  int sf;
-  int de;
-  int ps;
-  int band;
-  int header;
-  int cr;
+  int8_t sf;
+  int8_t de;
+  int8_t ps;
+  int16_t band;
+  int8_t header;
+  int8_t cr;
 } airtime_t;
 
 class TheThingsNetwork
@@ -38,33 +38,33 @@ class TheThingsNetwork
     airtime_t info;
     float airtime;
     ttn_fp_t fp;
-    int sf;
-    int fsb;
-    void (* messageCallback)(const byte* payload, int length, int port);
+    int8_t sf;
+    int8_t fsb;
+    void (* messageCallback)(const byte* payload, size_t length, int8_t port);
 
     String readLine();
     void fillAirtimeInfo();
-    void trackAirtime(int payloadSize);
+    void trackAirtime(size_t payloadSize);
     String readValue(String key);
     bool sendCommand(String cmd);
     bool sendCommand(String cmd, String value);
-    bool sendCommand(String cmd, const byte* buf, int length);
+    bool sendCommand(String cmd, const byte* buf, size_t length);
     void reset(bool adr = true);
-    void configureEU868(int sf);
-    void configureUS915(int sf, int fsb);
-    void configureChannels(int sf, int fsb);
+    void configureEU868(int8_t sf);
+    void configureUS915(int8_t sf, int8_t fsb);
+    void configureChannels(int8_t sf, int8_t fsb);
 
   public:
-    TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, int sf = TTN_DEFAULT_SF, int fsb = TTN_DEFAULT_FSB);
+    TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, int8_t sf = TTN_DEFAULT_SF, int8_t fsb = TTN_DEFAULT_FSB);
     void showStatus();
-    void onMessage(void (*cb)(const byte* payload, int length, int port));
+    void onMessage(void (*cb)(const byte* payload, size_t length, int8_t port));
     bool provision(const byte appEui[8], const byte appKey[16]);
-    bool join(const byte appEui[8], const byte appKey[16], int retries = -1, long int retryDelay = 10000);
-    bool join(int retries = -1, long int retryDelay = 10000);
+    bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, int32_t retryDelay = 10000);
+    bool join(int8_t retries = -1, int32_t retryDelay = 10000);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool personalize();
-    int sendBytes(const byte* payload, int length, int port = 1, bool confirm = false);
-    int poll(int port = 1, bool confirm = false);
+    int sendBytes(const byte* payload, size_t length, int8_t port = 1, bool confirm = false);
+    int poll(int8_t port = 1, bool confirm = false);
 };
 
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -21,12 +21,12 @@ enum ttn_fp_t {
 
 typedef struct  airtime_s
 {
-  int8_t sf;
-  int8_t de;
-  int8_t ps;
-  int16_t band;
-  int8_t header;
-  int8_t cr;
+  uint8_t sf;
+  uint8_t de;
+  uint8_t ps;
+  uint16_t band;
+  uint8_t header;
+  uint8_t cr;
 } airtime_t;
 
 class TheThingsNetwork
@@ -38,9 +38,9 @@ class TheThingsNetwork
     airtime_t info;
     float airtime;
     ttn_fp_t fp;
-    int8_t sf;
-    int8_t fsb;
-    void (* messageCallback)(const byte* payload, size_t length, int8_t port);
+    uint8_t sf;
+    uint8_t fsb;
+    void (* messageCallback)(const byte* payload, size_t length, uint8_t port);
 
     String readLine();
     void fillAirtimeInfo();
@@ -50,21 +50,21 @@ class TheThingsNetwork
     bool sendCommand(String cmd, String value);
     bool sendCommand(String cmd, const byte* buf, size_t length);
     void reset(bool adr = true);
-    void configureEU868(int8_t sf);
-    void configureUS915(int8_t sf, int8_t fsb);
-    void configureChannels(int8_t sf, int8_t fsb);
+    void configureEU868(uint8_t sf);
+    void configureUS915(uint8_t sf, uint8_t fsb);
+    void configureChannels(uint8_t sf, uint8_t fsb);
 
   public:
-    TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, int8_t sf = TTN_DEFAULT_SF, int8_t fsb = TTN_DEFAULT_FSB);
+    TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, uint8_t sf = TTN_DEFAULT_SF, uint8_t fsb = TTN_DEFAULT_FSB);
     void showStatus();
-    void onMessage(void (*cb)(const byte* payload, size_t length, int8_t port));
+    void onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port));
     bool provision(const byte appEui[8], const byte appKey[16]);
-    bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, int32_t retryDelay = 10000);
-    bool join(int8_t retries = -1, int32_t retryDelay = 10000);
+    bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, uint32_t retryDelay = 10000);
+    bool join(int8_t retries = -1, uint32_t retryDelay = 10000);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool personalize();
-    int sendBytes(const byte* payload, size_t length, int8_t port = 1, bool confirm = false);
-    int poll(int8_t port = 1, bool confirm = false);
+    int sendBytes(const byte* payload, size_t length, uint8_t port = 1, bool confirm = false);
+    int poll(uint8_t port = 1, bool confirm = false);
 };
 
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -14,6 +14,8 @@
 #define TTN_PWRIDX_868 1
 #define TTN_PWRIDX_915 5
 
+typedef uint8_t port_t;
+
 enum ttn_fp_t {
   TTN_FP_EU868,
   TTN_FP_US915
@@ -32,6 +34,7 @@ typedef struct  airtime_s
 class TheThingsNetwork
 {
   private:
+    port_t port;
     Stream* modemStream;
     Stream* debugStream;
     String model;
@@ -40,7 +43,7 @@ class TheThingsNetwork
     ttn_fp_t fp;
     uint8_t sf;
     uint8_t fsb;
-    void (* messageCallback)(const byte* payload, size_t length, uint8_t port);
+    void (* messageCallback)(const byte* payload, size_t length, port_t port);
 
     String readLine();
     void fillAirtimeInfo();
@@ -57,14 +60,14 @@ class TheThingsNetwork
   public:
     TheThingsNetwork(Stream& modemStream, Stream& debugStream, ttn_fp_t fp, uint8_t sf = TTN_DEFAULT_SF, uint8_t fsb = TTN_DEFAULT_FSB);
     void showStatus();
-    void onMessage(void (*cb)(const byte* payload, size_t length, uint8_t port));
+    void onMessage(void (*cb)(const byte* payload, size_t length, port_t port));
     bool provision(const byte appEui[8], const byte appKey[16]);
     bool join(const byte appEui[8], const byte appKey[16], int8_t retries = -1, uint32_t retryDelay = 10000);
     bool join(int8_t retries = -1, uint32_t retryDelay = 10000);
     bool personalize(const byte devAddr[4], const byte nwkSKey[16], const byte appSKey[16]);
     bool personalize();
-    int sendBytes(const byte* payload, size_t length, uint8_t port = 1, bool confirm = false);
-    int poll(uint8_t port = 1, bool confirm = false);
+    int sendBytes(const byte* payload, size_t length, port_t port = 1, bool confirm = false);
+    int poll(port_t port = 1, bool confirm = false);
 };
 
 #endif


### PR DESCRIPTION
Changed types in example and files .cpp and .h: int to int8_t, int16_t, int32_t or size_t #103 