### PR TITLE
Remove obsolete documentation about calculated air time

### DIFF
--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -61,7 +61,6 @@ Band: 868
 Data Rate: 5
 RX Delay 1: 1000
 RX Delay 2: 2000
-Total airtime: 0.00 s
 ```
 
 See the [DeviceInfo](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/DeviceInfo/DeviceInfo.ino) example.
@@ -139,8 +138,6 @@ Returns a success or error code and logs the related error message:
 * `TTN_ERROR_UNEXPECTED_RESPONSE`: Unexpected response: \<Response>
 
 See the [Send](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/Send/Send.ino) example.
-
-Also in sendBytes, due to TTN's 30 second fair access policy, we update the airtime each time we uplink a message. This airtime is based on a lot of variables but the most important ones are the spreading factor and the size of the message, the higher it is the less messages you can send in 30 seconds (SF7 around 500 messages of 8 bytes, SF12 around 20 messages of 8 bytes).
 
 ## Method: `poll`
 


### PR DESCRIPTION
The references in the documentation are obsolete: it seems [the code to calculate air time](https://github.com/TheThingsNetwork/arduino-device-lib/commit/6256981705e55236f1e99378893e9471615260d1) was [removed in February 2017](https://github.com/TheThingsNetwork/arduino-device-lib/commit/ec549b37e4cbf8d4dc6f0a4a2db8b39e2eb2c3aa); TheThingsNetwork/arduino-device-lib#183.