### PR TITLE
Feature/prevent inf loop

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -438,7 +438,6 @@ void TheThingsNetwork::saveState()
   sendCommand(MAC_TABLE, MAC_SAVE, false);
   modemStream->write(SEND_MSG);
   debugPrintLn();
-  waitForOk();
 }
 
 void TheThingsNetwork::onMessage(void (*cb)(const uint8_t *payload, size_t size, port_t port))

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -349,11 +349,9 @@ size_t TheThingsNetwork::readLine(char *buffer, size_t size)
 {
   size_t read = 0;
   uint8_t loops = 10;
-  //Try a maximum of 10x1000ms to read data.
-  while (read == 0 && loops>0)
+  while (read == 0 && loops > 0)
   {
     loops--;
-    //readBytesUntil will timeout after 1000ms if nothing is read.
     read = modemStream->readBytesUntil('\n', buffer, size);
   }
   buffer[read - 1] = '\0'; // set \r to \0

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -587,7 +587,7 @@ void TheThingsNetwork::showStatus()
 {
   readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_HWEUI, buffer, sizeof(buffer));
   debugPrintIndex(SHOW_EUI, buffer);
-  if(strlen(buffer) < 16)
+  if (strlen(buffer) < 16)
   {
     debugPrintMessage(ERR_MESSAGE, ERR_UNEXPECTED_RESPONSE);
     return;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -588,7 +588,7 @@ void TheThingsNetwork::showStatus()
 {
   readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_HWEUI, buffer, sizeof(buffer));
   debugPrintIndex(SHOW_EUI, buffer);
-  if(strlen(buffer)<16)
+  if(strlen(buffer) < 16)
   {
     debugPrintMessage(ERR_MESSAGE, ERR_UNEXPECTED_RESPONSE);
     return;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -345,13 +345,12 @@ void TheThingsNetwork::clearReadBuffer()
   }
 }
 
-size_t TheThingsNetwork::readLine(char *buffer, size_t size)
+size_t TheThingsNetwork::readLine(char *buffer, size_t size, uint8_t timeout)
 {
   size_t read = 0;
-  uint8_t loops = 10;
-  while (read == 0 && loops > 0)
+  while (read == 0 && timeout > 0)
   {
-    loops--;
+    timeout--;
     read = modemStream->readBytesUntil('\n', buffer, size);
   }
   buffer[read - 1] = '\0'; // set \r to \0

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -345,12 +345,12 @@ void TheThingsNetwork::clearReadBuffer()
   }
 }
 
-size_t TheThingsNetwork::readLine(char *buffer, size_t size, uint8_t timeout)
+size_t TheThingsNetwork::readLine(char *buffer, size_t size, uint8_t attempts)
 {
   size_t read = 0;
-  while (read == 0 && timeout > 0)
+  while (read == 0 && attempts > 0)
   {
-    timeout--;
+    attempts--;
     read = modemStream->readBytesUntil('\n', buffer, size);
   }
   buffer[read - 1] = '\0'; // set \r to \0

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -591,6 +591,11 @@ void TheThingsNetwork::showStatus()
 {
   readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_HWEUI, buffer, sizeof(buffer));
   debugPrintIndex(SHOW_EUI, buffer);
+  if(strlen(buffer)<16)
+  {
+    debugPrintMessage(ERR_MESSAGE, ERR_UNEXPECTED_RESPONSE);
+    return;
+  }
   readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VDD, buffer, sizeof(buffer));
   debugPrintIndex(SHOW_BATTERY, buffer);
   readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_APPEUI, buffer, sizeof(buffer));

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -348,8 +348,12 @@ void TheThingsNetwork::clearReadBuffer()
 size_t TheThingsNetwork::readLine(char *buffer, size_t size)
 {
   size_t read = 0;
-  while (read == 0)
+  uint8_t loops = 10;
+  //Try a maximum of 10x1000ms to read data.
+  while (read == 0 && loops>0)
   {
+    loops--;
+    //readBytesUntil will timeout after 1000ms if nothing is read.
     read = modemStream->readBytesUntil('\n', buffer, size);
   }
   buffer[read - 1] = '\0'; // set \r to \0

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -53,7 +53,7 @@ private:
   void (*messageCallback)(const uint8_t *payload, size_t size, port_t port);
 
   void clearReadBuffer();
-  size_t readLine(char *buffer, size_t size);
+  size_t readLine(char *buffer, size_t size, uint8_t timeout = 10);
   size_t readResponse(uint8_t prefixTable, uint8_t indexTable, uint8_t index, char *buffer, size_t size);
   size_t readResponse(uint8_t table, uint8_t index, char *buffer, size_t size);
 

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -53,7 +53,7 @@ private:
   void (*messageCallback)(const uint8_t *payload, size_t size, port_t port);
 
   void clearReadBuffer();
-  size_t readLine(char *buffer, size_t size, uint8_t timeout = 10);
+  size_t readLine(char *buffer, size_t size, uint8_t attempts = 10);
   size_t readResponse(uint8_t prefixTable, uint8_t indexTable, uint8_t index, char *buffer, size_t size);
   size_t readResponse(uint8_t table, uint8_t index, char *buffer, size_t size);
 


### PR DESCRIPTION
Prevent an infinite loop in the `readLine` function. An infinite loop might occur when the wrong Serial port is defined. Therefore print out an error in the `showStatus` function, returning after 10 seconds, rather than waiting indefinitely.