### PR TITLE
Always sync baud on reset and after module reset

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -401,12 +401,11 @@ void TheThingsNetwork::autoBaud()
 
 void TheThingsNetwork::reset(bool adr)
 {
-  if (!baudDetermined)
-  {
-    autoBaud();
-  }
-
+  autoBaud();
   size_t length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
+
+  autoBaud();
+  length = readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VER, buffer, sizeof(buffer));  
 
   // buffer contains "RN2xx3[xx] x.x.x ...", splitting model from version
   char *model = strtok(buffer, " ");

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -401,10 +401,8 @@ void TheThingsNetwork::autoBaud()
 
 void TheThingsNetwork::reset(bool adr)
 {
-  size_t length;
-  
   autoBaud();
-  length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
+  size_t length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
 
   autoBaud();
   length = readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VER, buffer, sizeof(buffer));  

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -401,8 +401,10 @@ void TheThingsNetwork::autoBaud()
 
 void TheThingsNetwork::reset(bool adr)
 {
+  size_t length;
+  
   autoBaud();
-  size_t length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
+  length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
 
   autoBaud();
   length = readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VER, buffer, sizeof(buffer));  


### PR DESCRIPTION
When the MCU baud rate is different from default it is necessary to "autobaud" again after the module reset. Also, the response message after a reset is not readble if the MCU is working on a different baud rate. For this reason it it neccessary to issue another "autobaud" and a SYS_GET_VER to leave unchanged the behaviour of this function, that is reply with module informations.