### PR TITLE
Link check command feature

### DIFF
--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -193,3 +193,19 @@ void linkCheck(uint16_t seconds);
 ```
 
 - `uint16_t seconds`: the time interval in seconds. A value of 0 will disable the link check process.
+
+## Method: `getLinkCheckGateways`
+
+Gets the number of gateways that successfully received the last Link Check Request frame.
+
+```c
+uint8_t getLinkCheckGateways();
+```
+
+## Method: `getLinkCheckMargin`
+
+Gets the demodulation margin as received in the last Link Check Answer frame.
+
+```c
+uint8_t getLinkCheckMargin();
+```

--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -175,3 +175,12 @@ void sleep(unsigned long mseconds);
 ```
 
 - `unsigned long mseconds`: number of milliseconds to sleep.
+
+## Method: `wake`
+
+Wake up the LoRa module from sleep before the expiration of the defined time.
+
+```c
+void wake();
+```
+

--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -184,3 +184,12 @@ Wake up the LoRa module from sleep before the expiration of the defined time.
 void wake();
 ```
 
+## Method: `linkCheck`
+
+Sets the time interval for the link check process to be triggered.
+
+```c
+void linkCheck(uint16_t seconds);
+```
+
+- `uint16_t seconds`: the time interval in seconds. A value of 0 will disable the link check process.

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -978,13 +978,6 @@ void TheThingsNetwork::linkcheck(uint16_t seconds)
   return waitForOk();  
 }
 
-uint8_t TheThingsNetwork::linkcheckMargin()
-{
-  readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_MRGN, buffer, sizeof(buffer));
-
-  return strtol(buffer, NULL, 10);
-}
-
 uint8_t TheThingsNetwork::linkcheckGateways()
 {
   readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_GWNB, buffer, sizeof(buffer));
@@ -992,3 +985,9 @@ uint8_t TheThingsNetwork::linkcheckGateways()
   return strtol(buffer, NULL, 10);
 }
 
+uint8_t TheThingsNetwork::linkcheckMargin()
+{
+  readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_MRGN, buffer, sizeof(buffer));
+
+  return strtol(buffer, NULL, 10);
+}

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -975,7 +975,7 @@ void TheThingsNetwork::linkcheck(uint16_t seconds)
   modemStream->write(buffer);
   modemStream->write(SEND_MSG);
   debugPrintLn(buffer);
-  return waitForOk();  
+  waitForOk();  
 }
 
 uint8_t TheThingsNetwork::linkcheckGateways()

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -968,7 +968,7 @@ void TheThingsNetwork::wake()
   autoBaud();
 }
 
-void TheThingsNetwork::linkcheck(uint16_t seconds)
+void TheThingsNetwork::linkCheck(uint16_t seconds)
 {
   clearReadBuffer();
   debugPrint(SENDING);
@@ -983,16 +983,14 @@ void TheThingsNetwork::linkcheck(uint16_t seconds)
   waitForOk();  
 }
 
-uint8_t TheThingsNetwork::linkcheckGateways()
+uint8_t TheThingsNetwork::getLinkCheckGateways()
 {
   readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_GWNB, buffer, sizeof(buffer));
-
   return strtol(buffer, NULL, 10);
 }
 
-uint8_t TheThingsNetwork::linkcheckMargin()
+uint8_t TheThingsNetwork::getLinkCheckMargin()
 {
   readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_MRGN, buffer, sizeof(buffer));
-
   return strtol(buffer, NULL, 10);
 }

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -190,8 +190,10 @@ const char mac_band[] PROGMEM = "band";
 const char mac_ar[] PROGMEM = "ar";
 const char mac_rx2[] PROGMEM = "rx2";
 const char mac_ch[] PROGMEM = "ch";
+const char mac_gwnb[] PROGMEM = "gwnb";
+const char mac_mrgn[] PROGMEM = "mrgn";
 
-const char *const mac_options[] PROGMEM = {mac_devaddr, mac_deveui, mac_appeui, mac_nwkskey, mac_appskey, mac_appkey, mac_pwridx, mac_dr, mac_adr, mac_bat, mac_retx, mac_linkchk, mac_rxdelay1, mac_rxdelay2, mac_band, mac_ar, mac_rx2, mac_ch};
+const char *const mac_options[] PROGMEM = {mac_devaddr, mac_deveui, mac_appeui, mac_nwkskey, mac_appskey, mac_appkey, mac_pwridx, mac_dr, mac_adr, mac_bat, mac_retx, mac_linkchk, mac_rxdelay1, mac_rxdelay2, mac_band, mac_ar, mac_rx2, mac_ch, mac_gwnb, mac_mrgn};
 
 #define MAC_DEVADDR 0
 #define MAC_DEVEUI 1
@@ -211,6 +213,8 @@ const char *const mac_options[] PROGMEM = {mac_devaddr, mac_deveui, mac_appeui, 
 #define MAC_AR 15
 #define MAC_RX2 16
 #define MAC_CH 17
+#define MAC_GWNB 18
+#define MAC_MRGN 19
 
 const char mac_join_mode_otaa[] PROGMEM = "otaa";
 const char mac_join_mode_abp[] PROGMEM = "abp";
@@ -958,3 +962,33 @@ void TheThingsNetwork::sleep(uint32_t mseconds)
   modemStream->write(SEND_MSG);
   debugPrintLn(buffer);
 }
+
+void TheThingsNetwork::linkcheck(uint16_t seconds)
+{
+  clearReadBuffer();
+  debugPrint(SENDING);
+  sendCommand(MAC_TABLE, MAC_PREFIX, true);
+  sendCommand(MAC_TABLE, MAC_SET, true);
+  sendCommand(MAC_GET_SET_TABLE, MAC_LINKCHK, true);
+
+  sprintf(buffer, "%u", seconds);
+  modemStream->write(buffer);
+  modemStream->write(SEND_MSG);
+  debugPrintLn(buffer);
+  return waitForOk();  
+}
+
+uint8_t TheThingsNetwork::linkcheckMargin()
+{
+  readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_MRGN, buffer, sizeof(buffer));
+
+  return strtol(buffer, NULL, 10);
+}
+
+uint8_t TheThingsNetwork::linkcheckGateways()
+{
+  readResponse(MAC_TABLE, MAC_GET_SET_TABLE, MAC_GWNB, buffer, sizeof(buffer));
+
+  return strtol(buffer, NULL, 10);
+}
+

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -93,6 +93,9 @@ public:
   ttn_response_t poll(port_t port = 1, bool confirm = false);
   void sleep(uint32_t mseconds);
   void saveState();
+  void linkcheck(uint16_t seconds);
+  uint8_t linkcheckGateways();  
+  uint8_t linkcheckMargin();
 };
 
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -94,9 +94,9 @@ public:
   void sleep(uint32_t mseconds);
   void wake();
   void saveState();
-  void linkcheck(uint16_t seconds);
-  uint8_t linkcheckGateways();  
-  uint8_t linkcheckMargin();
+  void linkCheck(uint16_t seconds);
+  uint8_t getLinkCheckGateways();  
+  uint8_t getLinkCheckMargin();
 };
 
 #endif


### PR DESCRIPTION
Currently there is no method to check if a node is really still joined to TTN or if the gateway/s in range, is/are still up and running.
The "join bit" of "mac get status" response is not reliable... indeed if the only gateway in range is stopped this bit continues to return 1 (joined). Nothing strange since the rule is fire-and-forget.

A work around could then use "mac set linkchk nnn". 

_This function sets the time interval for the link check process to be triggered periodically. A <value> of ‘0’ will disable the link check process. When the time interval expires, the next application packet that will be sent to the server will include a link check MAC command. Refer to the LoRaWAN Specification V1.0 document for more information on the link check configuration._


Thanks to this command is it possible then get the number of gateways in range and the demodulation margin in dB returned on the last check.

NB: to not disobey at the TTN Fair Access Policy is in charge of those who use it to make the number of downlink stay within the limits allowed. The max value for "nnn" is 65.535 which corresponds to an interval of 18 hours about.

I've tested this method on my end node and gateway and it seems realiable, see this piece of log:


```
-- LINK CHECK ENABLED
-- GATEWAYS 1 - MARGIN 16
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
-- LINK CHECK ENABLED
-- GATEWAYS 0 - MARGIN 255
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
-- LINK CHECK ENABLED
-- GATEWAYS 0 - MARGIN 255
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
-- LINK CHECK ENABLED
-- GATEWAYS 0 - MARGIN 255
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
-- LINK CHECK ENABLED
-- GATEWAYS 0 - MARGIN 255
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
-- LINK CHECK ENABLED
-- GATEWAYS 1 - MARGIN 17
Sending: mac tx uncnf 1 08011D0000F041250000AC422D0000C242
Successful transmission
Sending: sys sleep 60000
```

**Explanation: after the classic OTAA the values returned was "-- GATEWAYS 1 - MARGIN 16" then I stopped the "ttn-pkt-fwd" service and it became "-- GATEWAYS 0 - MARGIN 255"... then restarting again "ttn-pkt-fwd" returned to be "GATEWAYS 1 - MARGIN 17".**


