### PR TITLE
Fixed LoRa module not waked from sleep by autoBaud sometimes

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -387,7 +387,7 @@ size_t TheThingsNetwork::readResponse(uint8_t prefixTable, uint8_t indexTable, u
   return readLine(buffer, size);
 }
 
-size_t TheThingsNetwork::checkComm()
+size_t TheThingsNetwork::checkModuleAvailable()
 {
     // Send sys get ver check we have an answer
     sendCommand(SYS_TABLE, 0, true, false);
@@ -411,10 +411,10 @@ void TheThingsNetwork::autoBaud()
     modemStream->write(0x55);
     modemStream->write(SEND_MSG);
     // check we can talk
-    length = checkComm();
+    length = checkModuleAvailable();
     
     // We succeded talking to the module ?
-    baudDetermined = length ? true : false;
+    baudDetermined = length > 0 ? true : false;
   }
   delay(100);
   clearReadBuffer();
@@ -440,7 +440,7 @@ void TheThingsNetwork::wake()
     pLora->write((uint8_t)0x55);
     pLora->flush();
     pLora->write(SEND_MSG);
-    if (checkComm()>0) {
+    if (checkModuleAvailable()>0) {
       baudDetermined = true;
       sleeping = false;
     }

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -287,7 +287,7 @@ uint8_t receivedPort(const char *s)
   return port;
 }
 
-TheThingsNetwork::TheThingsNetwork(Stream &modemStream, Stream &debugStream, ttn_fp_t fp, uint8_t sf, uint8_t fsb)
+TheThingsNetwork::TheThingsNetwork(SerialType &modemStream, Stream &debugStream, ttn_fp_t fp, uint8_t sf, uint8_t fsb)
 {
   this->debugStream = &debugStream;
   this->modemStream = &modemStream;
@@ -419,23 +419,21 @@ void TheThingsNetwork::autoBaud()
 
 void TheThingsNetwork::wake()
 {  
-  HardwareSerial *pLora = (HardwareSerial*) modemStream;
-  
   // If sleeping
   if (sleeping) 
   {
     // Send a 0 at lower speed to be sure always received
     // as a character a 57600 baud rate
-    pLora->flush();
-    pLora->begin(2400);
-    pLora->write((uint8_t) 0x00);
-    pLora->flush();
+    modemStream->flush();
+    modemStream->begin(2400);
+    modemStream->write((uint8_t) 0x00);
+    modemStream->flush();
     delay(20);
     // set baudrate back to normal and send autobaud
-    pLora->begin(57600);
-    pLora->write((uint8_t)0x55);
-    pLora->flush();
-    pLora->write(SEND_MSG);
+    modemStream->begin(57600);
+    modemStream->write((uint8_t)0x55);
+    modemStream->flush();
+    modemStream->write(SEND_MSG);
     if (checkModuleAvailable() > 0) {
       baudDetermined = true;
       sleeping = false;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -409,8 +409,8 @@ void TheThingsNetwork::autoBaud()
     // check we can talk
     length = checkModuleAvailable();
     
-    // We succeded talking to the module ?
-    baudDetermined = length > 0 ;
+    // We succeeded talking to the module ?
+    baudDetermined = (length > 0) ;
   }
   delay(100);
   clearReadBuffer();
@@ -419,13 +419,13 @@ void TheThingsNetwork::autoBaud()
 
 bool TheThingsNetwork::isSleeping()
 {  
-  return baudDetermined ? false : true ;
+  return !baudDetermined;
 }
 
 void TheThingsNetwork::wake()
 {  
   // If sleeping
-  if (!baudDetermined) 
+  if (isSleeping()) 
   {
     // Send a 0 at lower speed to be sure always received
     // as a character a 57600 baud rate
@@ -650,7 +650,7 @@ void TheThingsNetwork::showStatus()
   debugPrintIndex(SHOW_RX_DELAY_2, buffer);
 }
 
-// Puting this common fonction saves 238 bytes of flash
+// Puting this common function saves 238 bytes of flash
 void TheThingsNetwork::configureChannelsFreq(uint32_t freq, uint8_t first, uint8_t last, uint8_t first_dr)
 {
   uint8_t ch;

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -436,7 +436,7 @@ void TheThingsNetwork::wake()
     pLora->write((uint8_t)0x55);
     pLora->flush();
     pLora->write(SEND_MSG);
-    if (checkModuleAvailable()>0) {
+    if (checkModuleAvailable() > 0) {
       baudDetermined = true;
       sleeping = false;
     }

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -430,12 +430,16 @@ void TheThingsNetwork::wake()
     // Send a 0 at lower speed to be sure always received
     // as a character a 57600 baud rate
     modemStream->flush();
+#ifdef HARDWARE_UART
     modemStream->begin(2400);
+#endif
     modemStream->write((uint8_t) 0x00);
     modemStream->flush();
     delay(20);
     // set baudrate back to normal and send autobaud
+#ifdef HARDWARE_UART
     modemStream->begin(57600);
+#endif
     modemStream->write((uint8_t)0x55);
     modemStream->flush();
     modemStream->write(SEND_MSG);
@@ -646,16 +650,16 @@ void TheThingsNetwork::showStatus()
   debugPrintIndex(SHOW_RX_DELAY_2, buffer);
 }
 
-// Puting this common fonction save 238 bytes of flash
-void TheThingsNetwork::configureChannelsFreq(uint32_t freq, uint8_t begin, uint8_t end, uint8_t start)
+// Puting this common fonction saves 238 bytes of flash
+void TheThingsNetwork::configureChannelsFreq(uint32_t freq, uint8_t first, uint8_t last, uint8_t first_dr)
 {
   uint8_t ch;
   char buf[10];
 
-  for (ch = begin; ch < end; ch++)
+  for (ch = first; ch <= last; ch++)
   {
     sendChSet(MAC_CHANNEL_DCYCLE, ch, "799");
-    if (ch > start)
+    if (ch > first_dr)
     {
       sprintf(buf, "%lu", freq);
       sendChSet(MAC_CHANNEL_FREQ, ch, buf);
@@ -704,7 +708,6 @@ void TheThingsNetwork::configureAS920_923()
    * CH0 = 923.2MHz
    * CH1 = 923.4MHz
    */
-  sendMacSet(MAC_ADR, "off"); // TODO: remove when ADR is implemented for this plan
   sendMacSet(MAC_RX2, "2 923200000");
 
   configureChannelsFreq(922000000, 0, 8, 1);

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -410,7 +410,7 @@ void TheThingsNetwork::autoBaud()
     length = checkModuleAvailable();
     
     // We succeded talking to the module ?
-    baudDetermined = length > 0 ? true : false;
+    baudDetermined = length > 0 ;
   }
   delay(100);
   clearReadBuffer();

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -390,11 +390,7 @@ size_t TheThingsNetwork::readResponse(uint8_t prefixTable, uint8_t indexTable, u
 size_t TheThingsNetwork::checkModuleAvailable()
 {
     // Send sys get ver check we have an answer
-    sendCommand(SYS_TABLE, 0, true, false);
-    sendCommand(SYS_TABLE, SYS_GET, true, false);
-    sendCommand(SYS_TABLE, SYS_GET_VER, false, false);
-    modemStream->write(SEND_MSG);
-    return modemStream->readBytesUntil('\n', buffer, sizeof(buffer));
+    return readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VER, buffer, sizeof(buffer));  
 }
 
 void TheThingsNetwork::autoBaud()

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -417,10 +417,15 @@ void TheThingsNetwork::autoBaud()
   modemStream->setTimeout(10000);
 }
 
+bool TheThingsNetwork::isSleeping()
+{  
+  return baudDetermined ? false : true ;
+}
+
 void TheThingsNetwork::wake()
 {  
   // If sleeping
-  if (sleeping) 
+  if (!baudDetermined) 
   {
     // Send a 0 at lower speed to be sure always received
     // as a character a 57600 baud rate
@@ -436,7 +441,6 @@ void TheThingsNetwork::wake()
     modemStream->write(SEND_MSG);
     if (checkModuleAvailable() > 0) {
       baudDetermined = true;
-      sleeping = false;
     }
   }
 }
@@ -642,18 +646,16 @@ void TheThingsNetwork::showStatus()
   debugPrintIndex(SHOW_RX_DELAY_2, buffer);
 }
 
-void TheThingsNetwork::configureEU868()
+// Puting this common fonction save 238 bytes of flash
+void TheThingsNetwork::configureChannelsFreq(uint32_t freq, uint8_t begin, uint8_t end, uint8_t start)
 {
-  sendMacSet(MAC_RX2, "3 869525000");
-  sendChSet(MAC_CHANNEL_DRRANGE, 1, "0 6");
-
-  char buf[10];
-  uint32_t freq = 867100000;
   uint8_t ch;
-  for (ch = 0; ch < 8; ch++)
+  char buf[10];
+
+  for (ch = begin; ch < end; ch++)
   {
     sendChSet(MAC_CHANNEL_DCYCLE, ch, "799");
-    if (ch > 2)
+    if (ch > start)
     {
       sprintf(buf, "%lu", freq);
       sendChSet(MAC_CHANNEL_FREQ, ch, buf);
@@ -662,6 +664,13 @@ void TheThingsNetwork::configureEU868()
       freq = freq + 200000;
     }
   }
+}
+
+void TheThingsNetwork::configureEU868()
+{
+  sendMacSet(MAC_RX2, "3 869525000");
+  sendChSet(MAC_CHANNEL_DRRANGE, 1, "0 6");
+  configureChannelsFreq(867100000, 0, 8, 2);
   sendMacSet(MAC_PWRIDX, TTN_PWRIDX_EU868);
 }
 
@@ -698,21 +707,7 @@ void TheThingsNetwork::configureAS920_923()
   sendMacSet(MAC_ADR, "off"); // TODO: remove when ADR is implemented for this plan
   sendMacSet(MAC_RX2, "2 923200000");
 
-  char buf[10];
-  uint32_t freq = 922000000;
-  uint8_t ch;
-  for (ch = 0; ch < 8; ch++)
-  {
-    sendChSet(MAC_CHANNEL_DCYCLE, ch, "799");
-    if (ch > 1)
-    {
-      sprintf(buf, "%lu", freq);
-      sendChSet(MAC_CHANNEL_FREQ, ch, buf);
-      sendChSet(MAC_CHANNEL_DRRANGE, ch, "0 5");
-      sendChSet(MAC_CHANNEL_STATUS, ch, "on");
-      freq = freq + 200000;
-    }
-  }
+  configureChannelsFreq(922000000, 0, 8, 1);
   // TODO: SF7BW250/DR6 channel, not properly supported by RN2903AS yet
   //sendChSet(MAC_CHANNEL_DCYCLE, 8, "799");
   //sendChSet(MAC_CHANNEL_FREQ, 8, "922100000");
@@ -731,21 +726,7 @@ void TheThingsNetwork::configureAS923_925()
   sendMacSet(MAC_ADR, "off"); // TODO: remove when ADR is implemented for this plan
   sendMacSet(MAC_RX2, "2 923200000");
 
-  char buf[10];
-  uint32_t freq = 923600000;
-  uint8_t ch;
-  for (ch = 0; ch < 8; ch++)
-  {
-    sendChSet(MAC_CHANNEL_DCYCLE, ch, "799");
-    if (ch > 1)
-    {
-      sprintf(buf, "%lu", freq);
-      sendChSet(MAC_CHANNEL_FREQ, ch, buf);
-      sendChSet(MAC_CHANNEL_DRRANGE, ch, "0 5");
-      sendChSet(MAC_CHANNEL_STATUS, ch, "on");
-      freq = freq + 200000;
-    }
-  }
+  configureChannelsFreq(923600000, 0, 8, 1);
   // TODO: SF7BW250/DR6 channel, not properly supported by RN2903AS yet
   //sendChSet(MAC_CHANNEL_DCYCLE, 8, "799");
   //sendChSet(MAC_CHANNEL_FREQ, 8, "924500000");
@@ -764,18 +745,7 @@ void TheThingsNetwork::configureKR920_923()
   sendChSet(MAC_CHANNEL_STATUS, 0, "off");
   sendChSet(MAC_CHANNEL_STATUS, 1, "off");
 
-  char buf[10];
-  uint32_t freq = 922100000;
-  uint8_t ch;
-  for (ch = 2; ch < 9; ch++)
-  {
-    sendChSet(MAC_CHANNEL_DCYCLE, ch, "799");
-    sprintf(buf, "%lu", freq);
-    sendChSet(MAC_CHANNEL_FREQ, ch, buf);
-    sendChSet(MAC_CHANNEL_DRRANGE, ch, "0 5");
-    sendChSet(MAC_CHANNEL_STATUS, ch, "on");
-    freq = freq + 200000;
-  }
+  configureChannelsFreq(922100000, 2, 9, 0);
   sendMacSet(MAC_PWRIDX, TTN_PWRIDX_KR920_923);
 }
 
@@ -895,24 +865,13 @@ bool TheThingsNetwork::sendChSet(uint8_t index, uint8_t channel, const char *val
 {
   clearReadBuffer();
   char ch[5];
-  if (channel > 9)
-  {
-    ch[0] = ((channel - (channel % 10)) / 10) + 48;
-    ch[1] = (channel % 10) + 48;
-    ch[2] = '\0';
-  }
-  else
-  {
-    ch[0] = channel + 48;
-    ch[1] = '\0';
-  }
+  sprintf(ch, "%d ", channel);
   debugPrint(F(SENDING));
   sendCommand(MAC_TABLE, MAC_PREFIX, true);
   sendCommand(MAC_TABLE, MAC_SET, true);
   sendCommand(MAC_GET_SET_TABLE, MAC_CH, true);
   sendCommand(MAC_CH_TABLE, index, true);
   modemStream->write(ch);
-  modemStream->write(" ");
   modemStream->write(value);
   modemStream->write(SEND_MSG);
   debugPrint(channel);
@@ -940,44 +899,16 @@ bool TheThingsNetwork::sendPayload(uint8_t mode, uint8_t port, uint8_t *payload,
   sendCommand(MAC_TABLE, MAC_PREFIX, true);
   sendCommand(MAC_TABLE, MAC_TX, true);
   sendCommand(MAC_TX_TABLE, mode, true);
-  char sport[4];
-  if (port > 99)
-  {
-    sport[0] = ((port - (port % 100)) / 100) + 48;
-    sport[1] = (((port % 100) - (port % 10)) / 10) + 48;
-    sport[2] = (port % 10) + 48;
-    sport[3] = '\0';
-  }
-  else if (port > 9)
-  {
-    sport[0] = ((port - (port % 10)) / 10) + 48;
-    sport[1] = (port % 10) + 48;
-    sport[2] = '\0';
-  }
-  else
-  {
-    sport[0] = port + 48;
-    sport[1] = '\0';
-  }
-  modemStream->write(sport);
-  modemStream->print(" ");
-  debugPrint(sport);
-  debugPrint(F(" "));
+  char buf[5];
+  sprintf(buf, "%d ", port);
+  modemStream->write(buf);
+  debugPrint(buf);
   uint8_t i = 0;
   for (i = 0; i < length; i++)
   {
-    if (payload[i] < 16)
-    {
-      modemStream->print("0");
-      modemStream->print(payload[i], HEX);
-      debugPrint(F("0"));
-      debugPrint(payload[i], HEX);
-    }
-    else
-    {
-      modemStream->print(payload[i], HEX);
-      debugPrint(payload[i], HEX);
-    }
+    sprintf(buf, "%02X", payload[i] );
+    modemStream->print(buf);
+    debugPrint(buf);
   }
   modemStream->write(SEND_MSG);
   debugPrintLn();
@@ -1002,7 +933,6 @@ void TheThingsNetwork::sleep(uint32_t mseconds)
 
   // to be determined back on wake up
   baudDetermined = false;
-  sleeping = true;
 }
 
 void TheThingsNetwork::linkCheck(uint16_t seconds)

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -29,9 +29,6 @@ typedef HardwareSerial SerialType;
 typedef HardwareSerial SerialType;
 #define HARDWARE_UART
 
-#elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
-typedef Uart SerialType;
-#define HARDWARE_UART
 #else
 typedef Stream SerialType;
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -20,6 +20,14 @@
 
 #define TTN_BUFFER_SIZE 300
 
+#if defined(ARDUINO_ARCH_AVR)
+typedef HardwareSerial SerialType;
+#elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
+typedef Uart SerialType;
+#else
+typedef Stream SerialType;
+#endif
+
 typedef uint8_t port_t;
 
 enum ttn_response_t
@@ -42,7 +50,7 @@ enum ttn_fp_t
 class TheThingsNetwork
 {
 private:
-  Stream *modemStream;
+  SerialType *modemStream;
   Stream *debugStream;
   ttn_fp_t fp;
   uint8_t sf;
@@ -80,7 +88,7 @@ private:
   void sendGetValue(uint8_t table, uint8_t prefix, uint8_t index);
 
 public:
-  TheThingsNetwork(Stream &modemStream, Stream &debugStream, ttn_fp_t fp, uint8_t sf = TTN_DEFAULT_SF, uint8_t fsb = TTN_DEFAULT_FSB);
+  TheThingsNetwork(SerialType &modemStream, Stream &debugStream, ttn_fp_t fp, uint8_t sf = TTN_DEFAULT_SF, uint8_t fsb = TTN_DEFAULT_FSB);
   void reset(bool adr = true);
   void showStatus();
   size_t getHardwareEui(char *buffer, size_t size);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -8,6 +8,9 @@
 #include <Stream.h>
 #include <avr/pgmspace.h>
 
+// If you need to use soft serial library you need to uncomment this line
+//#define USE_SOFT_SERIAL
+
 #define TTN_DEFAULT_SF 7
 #define TTN_DEFAULT_FSB 2
 #define TTN_RETX "7"
@@ -20,6 +23,10 @@
 
 #define TTN_BUFFER_SIZE 300
 
+#ifdef USE_SOFT_SERIAL
+#include <AltSoftSerial.h>
+typedef AltSoftSerial SerialType;
+#else
 #if defined(ARDUINO_ARCH_AVR)
 typedef HardwareSerial SerialType;
 #elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
@@ -27,6 +34,7 @@ typedef Uart SerialType;
 #else
 typedef Stream SerialType;
 #endif
+#endif // USE_SOFT_SERIAL
 
 typedef uint8_t port_t;
 
@@ -58,7 +66,6 @@ private:
   bool adr;
   char buffer[512];
   bool baudDetermined = false;
-  bool sleeping = false;
   void (*messageCallback)(const uint8_t *payload, size_t size, port_t port);
 
   void clearReadBuffer();
@@ -71,6 +78,7 @@ private:
 
   size_t checkModuleAvailable();
   void autoBaud();
+  void configureChannelsFreq(uint32_t freq, uint8_t begin, uint8_t end, uint8_t start);
   void configureEU868();
   void configureUS915(uint8_t fsb);
   void configureAS920_923();
@@ -103,6 +111,7 @@ public:
   ttn_response_t sendBytes(const uint8_t *payload, size_t length, port_t port = 1, bool confirm = false, uint8_t sf = 0);
   ttn_response_t poll(port_t port = 1, bool confirm = false);
   void sleep(uint32_t mseconds);
+  bool isSleeping();
   void wake();
   void saveState();
   void linkCheck(uint16_t seconds);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -8,9 +8,6 @@
 #include <Stream.h>
 #include <avr/pgmspace.h>
 
-// If you need to use soft serial library you need to uncomment this line
-//#define USE_SOFT_SERIAL
-
 #define TTN_DEFAULT_SF 7
 #define TTN_DEFAULT_FSB 2
 #define TTN_RETX "7"
@@ -23,15 +20,18 @@
 
 #define TTN_BUFFER_SIZE 300
 
-// The Things Industries devices
+// The Things Products devices
 #if defined(ARDUINO_THINGS_NODE) || defined (ARDUINO_THINGS_UNO)
 typedef HardwareSerial SerialType;
+#define HARDWARE_UART
 
 #elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
 typedef HardwareSerial SerialType;
+#define HARDWARE_UART
 
 #elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
 typedef Uart SerialType;
+#define HARDWARE_UART
 #else
 typedef Stream SerialType;
 #endif
@@ -78,7 +78,7 @@ private:
 
   size_t checkModuleAvailable();
   void autoBaud();
-  void configureChannelsFreq(uint32_t freq, uint8_t begin, uint8_t end, uint8_t start);
+  void configureChannelsFreq(uint32_t freq, uint8_t first, uint8_t last, uint8_t first_dr);
   void configureEU868();
   void configureUS915(uint8_t fsb);
   void configureAS920_923();

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -50,6 +50,7 @@ private:
   bool adr;
   char buffer[512];
   bool baudDetermined = false;
+  bool sleeping = false;
   void (*messageCallback)(const uint8_t *payload, size_t size, port_t port);
 
   void clearReadBuffer();
@@ -60,6 +61,7 @@ private:
   void debugPrintIndex(uint8_t index, const char *value = NULL);
   void debugPrintMessage(uint8_t type, uint8_t index, const char *value = NULL);
 
+  size_t checkComm();
   void autoBaud();
   void configureEU868();
   void configureUS915(uint8_t fsb);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -61,7 +61,7 @@ private:
   void debugPrintIndex(uint8_t index, const char *value = NULL);
   void debugPrintMessage(uint8_t type, uint8_t index, const char *value = NULL);
 
-  size_t checkComm();
+  size_t checkModuleAvailable();
   void autoBaud();
   void configureEU868();
   void configureUS915(uint8_t fsb);

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -21,14 +21,10 @@
 #define TTN_BUFFER_SIZE 300
 
 // The Things Products devices
-#if defined(ARDUINO_THINGS_NODE) || defined (ARDUINO_THINGS_UNO)
+// Things Node only need this, we won't impact Things Uno user
+#if defined(ARDUINO_THINGS_NODE) 
 typedef HardwareSerial SerialType;
 #define HARDWARE_UART
-
-#elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
-typedef HardwareSerial SerialType;
-#define HARDWARE_UART
-
 #else
 typedef Stream SerialType;
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -23,18 +23,18 @@
 
 #define TTN_BUFFER_SIZE 300
 
-#ifdef USE_SOFT_SERIAL
-#include <AltSoftSerial.h>
-typedef AltSoftSerial SerialType;
-#else
-#if defined(ARDUINO_ARCH_AVR)
+// The Things Industries devices
+#if defined(ARDUINO_THINGS_NODE) || defined (ARDUINO_THINGS_UNO)
 typedef HardwareSerial SerialType;
+
+#elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
+typedef HardwareSerial SerialType;
+
 #elif defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_SAMD)
 typedef Uart SerialType;
 #else
 typedef Stream SerialType;
 #endif
-#endif // USE_SOFT_SERIAL
 
 typedef uint8_t port_t;
 


### PR DESCRIPTION
I increased the break time condition setting up serial port to lower baud rate when writing 0 (break) on wake method
Bug could be reproduced by non stop shaking the node, with this code, seem fixed

May be we could also arrange autoBaud to reflect this change and do only one method.