### PR TITLE
Fix regression for Arduino SAMD boards

### DIFF
--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -6,7 +6,7 @@
 
 #include <Arduino.h>
 #include <Stream.h>
-#ifdef ARDUINO_ARCH_AVR
+#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_SAMD)
 #include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>


### PR DESCRIPTION
The fix for #243 introduces a regression for Arduino SAMD boards (MKR series).

This PR checks for both AVR and SAMD architecture.