### PR TITLE
Enhanced documentation for linkCheck()

### DIFF
--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -186,7 +186,7 @@ void wake();
 
 ## Method: `linkCheck`
 
-Sets the time interval for the link check process to be triggered.
+Sets the time interval for the link check process to be triggered. When the interval expires, the next uplink will include a Link Check Request MAC command. When using this method, it should be called after joining has completed.
 
 ```c
 void linkCheck(uint16_t seconds);


### PR DESCRIPTION
Improved the documentation to mitigate confusion that showed in https://www.thethingsnetwork.org/forum/t/ttn-node-link-check-does-not-work/19981/18

- Calling `linkCheck` before joining has no effect.

- The `linkCheck` command is delegated to the RN2483 module by using `mac set linkchk`, which [is documented as](http://ww1.microchip.com/downloads/en/DeviceDoc/40001784C.pdf#page=29):

    > When the time interval expires, the next application packet that will be sent to the server will include also a link check MAC command.