### PR TITLE
Avoid compiler warning

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -420,7 +420,7 @@ void TheThingsNetwork::autoBaud()
 void TheThingsNetwork::reset(bool adr)
 {
   autoBaud();
-  size_t length = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
+  size_t length __attribute__((unused)) = readResponse(SYS_TABLE, SYS_RESET, buffer, sizeof(buffer));
 
   autoBaud();
   length = readResponse(SYS_TABLE, SYS_TABLE, SYS_GET_VER, buffer, sizeof(buffer));


### PR DESCRIPTION
This is more cosmetic than anything else, but I try to avoid unnecessary compiler warnings in builds.  
The `unused` attributes acknowledges the variable is unused and suppress the warning.

Alternatively we could cast `readResponse()` to `(void)` instead of using the `length` variable...
