### PR TITLE
Fix `readLine`'s `needsHardReset` condition

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -364,7 +364,7 @@ size_t TheThingsNetwork::readLine(char *buffer, size_t size, uint8_t attempts)
   {
     read = modemStream->readBytesUntil('\n', buffer, size);
   }
-  if (attempts<=0)
+  if (!read)
   { // If attempts is activated return 0 and set RN state marker
     this->needsHardReset = true; // Inform the application about the radio module is not responsive.
     debugPrintLn("No response from RN module.");


### PR DESCRIPTION
As is, `needsHardReset` is never set by `readLine`.

If reads are failing, when `attempt` is finally zero and causes the `while` loop to exit, it is also post-decremented and becomes 255 (since it is unsigned). Hence the condition to set `needsHardReset` is never met.

In fact, the condition `attempts<=0` is true only when the last read attempt actually succeeded. In this case, `attempt` was 1 and is decremented to 0 before the final call to `readBytesUntil` returns read>0. The `while` loop exits because `!read` is false and the value of `attempt` remains at 0, unchanged, because of short-circuited `&&`.

Use https://godbolt.org/z/000v_I as a playground to prove this to yourself.

The solution is to ignore `attempts` after the loop. It did its job already. The important question is whether `read` is zero or not. If so, we need to reset the module.