### PR TITLE
Fix build when using -Werror

### DIFF
--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -924,7 +924,7 @@ void TheThingsNetwork::configureChannels(uint8_t fsb)
 
 bool TheThingsNetwork::setSF(uint8_t sf)
 {
-  uint8_t dr;
+  uint8_t dr = 0;
   switch (fp)
   {
   case TTN_FP_EU868:

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -259,7 +259,7 @@ const char *const mac_tx_table[] PROGMEM = {mac_tx_type_cnf, mac_tx_type_ucnf};
 int pgmstrcmp(const char *str1, uint8_t str2Index)
 {
   char str2[128];
-  strcpy_P(str2, (char *)pgm_read_word(&(compare_table[str2Index])));
+  strcpy_P(str2, reinterpret_cast<char*>(pgm_read_word(&(compare_table[str2Index]))));
   return memcmp(str1, str2, min(strlen(str1), strlen(str2)));
 }
 
@@ -320,7 +320,7 @@ uint16_t TheThingsNetwork::getVDD()
 void TheThingsNetwork::debugPrintIndex(uint8_t index, const char *value)
 {
   char message[100];
-  strcpy_P(message, (char *)pgm_read_word(&(show_table[index])));
+  strcpy_P(message, reinterpret_cast<char*>(pgm_read_word(&(show_table[index]))));
   debugPrint(message);
   if (value)
   {
@@ -334,10 +334,10 @@ void TheThingsNetwork::debugPrintMessage(uint8_t type, uint8_t index, const char
   switch (type)
   {
   case ERR_MESSAGE:
-    strcpy_P(message, (char *)pgm_read_word(&(error_msg[index])));
+    strcpy_P(message, reinterpret_cast<char*>(pgm_read_word(&(error_msg[index]))));
     break;
   case SUCCESS_MESSAGE:
-    strcpy_P(message, (char *)pgm_read_word(&(success_msg[index])));
+    strcpy_P(message, reinterpret_cast<char*>(pgm_read_word(&(success_msg[index]))));
     break;
   }
   debugPrint(message);
@@ -951,25 +951,25 @@ void TheThingsNetwork::sendCommand(uint8_t table, uint8_t index, bool appendSpac
   switch (table)
   {
   case MAC_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(mac_table[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(mac_table[index]))));
     break;
   case MAC_GET_SET_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(mac_options[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(mac_options[index]))));
     break;
   case MAC_JOIN_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(mac_join_mode[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(mac_join_mode[index]))));
     break;
   case MAC_CH_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(mac_ch_options[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(mac_ch_options[index]))));
     break;
   case MAC_TX_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(mac_tx_table[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(mac_tx_table[index]))));
     break;
   case SYS_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(sys_table[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(sys_table[index]))));
     break;
   case RADIO_TABLE:
-    strcpy_P(command, (char *)pgm_read_word(&(radio_table[index])));
+    strcpy_P(command, reinterpret_cast<char*>(pgm_read_word(&(radio_table[index]))));
     break;
   default:
     return;


### PR DESCRIPTION
This fixes two issues when building with -Werror

```
lib\arduino-device-lib\src\TheThingsNetwork.cpp: In member function 'bool TheThingsNetwork::setSF(uint8_t)':
lib\arduino-device-lib\src\TheThingsNetwork.cpp:943:14: error: 'dr' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  943 |   s[0] = '0' + dr;
      |          ~~~~^~~~
cc1plus.exe: all warnings being treated as errors
*** [.pio\build\genericSTM32F407VGT6\lib0bc\arduino-device-lib\TheThingsNetwork.cpp.o] Error 1
```

```
lib\arduino-device-lib\src\TheThingsNetwork.cpp: In function 'int pgmstrcmp(const char*, uint8_t)':
lib\arduino-device-lib\src\TheThingsNetwork.cpp:262:69: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  262 |   strcpy_P(str2, (char *)(pgm_read_word(&(compare_table[str2Index]))));
      |                                                                     ^
C:\Users\lukas\.platformio\packages\framework-arduinoststm32\cores\arduino/avr/pgmspace.h:55:45: note: in definition of macro 'strcpy_P'
   55 | #define strcpy_P(dest, src) strcpy((dest), (src))
      |                                             ^~~
cc1plus.exe: all warnings being treated as errors
*** [.pio\build\genericSTM32F407VGT6\lib0bc\arduino-device-lib\TheThingsNetwork.cpp.o] Error 1
```