### PR TITLE
Improve handling of needsHardReset flag and add method to check valid module connected to serial port

### DIFF
--- a/docs/TheThingsNetwork.md
+++ b/docs/TheThingsNetwork.md
@@ -54,6 +54,14 @@ Gets the provisioned AppEUI. The AppEUI is set using `provision()` or `join()`.
 size_t getAppEui(char *buffer, size_t size);
 ```
 
+## Method: `getVersion`
+
+Gets the response from a `sys get ver` command (i.e. the hardware model, the the software version, etc.).
+
+```c
+size_t getVersion(char *buffer, size_t size);
+```
+
 ## Method: `showStatus`
 
 Writes information about the device and LoRa module to `debugStream`.
@@ -114,13 +122,14 @@ Call the method without the first two arguments if the device's LoRa module come
 Activate the device via ABP.
 
 ```c
-bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey);
+bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool reset_first);
 bool personalize();
 ```
 
 - `const char *devAddr`: Device Address assigned to the device.
 - `const char *nwkSKey`: Network Session Key assigned to the device for identification.
 - `const char *appSKey`: Application Session Key assigned to the device for encryption.
+- `bool reset_first`: Soft reset the module before performing any other action. Default is `true`.
 
 Returns `true` or `false` depending on whether the activation was successful.
 
@@ -192,11 +201,12 @@ See the [Receive](https://github.com/TheThingsNetwork/arduino-device-lib/blob/ma
 Sets the information needed to activate the device via OTAA, without actually activating. Call join() without the first 2 arguments to activate.
 
 ```c
-bool provision(const char *appEui, const char *appKey);
+bool provision(const char *appEui, const char *appKey, bool reset_first);
 ```
 
 - `const char *appEui`: Application Identifier for the device.
 - `const char *appKey`: Application Key assigned to the device.
+- `bool reset_first`: Soft reset the module before performing any other action. Default is `true`.
 
 ## Method: `sleep`
 
@@ -433,6 +443,28 @@ When transmitting in LoRaWan, we usually operate on a TX window and two RX windo
 ```c
 bool setRX1Delay(uint16_t delay);
 ```
+
+## Method: `checkValidModuleConnected`
+
+Checks if a valid module is connected to the configured serial port. Useful to check for connectivity with a supported module before performing any other actions.
+
+```c
+bool checkValidModuleConnected(bool autobaud_first);
+```
+
+- `bool autobaud_first`: Perform a call to `autoBaud()` before checking connection. Default is `false`.
+
+Returns:
+
+* `false` if no response was received (i.e. `needsHardReset` is `true`)
+* `false` if the module is invalid (unsupported), i.e. **not** one of the following:
+    * `RN2483`
+    * `RN2483A`
+    * `RN2903`
+    * `RN2903AS`
+* `true` if the module responded (i.e. `needsHardReset` is `false`) and is valid (supported).
+
+See the [CheckModule](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/CheckModule/CheckModule.ino) example.
 
 # Additional for statistics 
 

--- a/examples/CheckModule/CheckModule.ino
+++ b/examples/CheckModule/CheckModule.ino
@@ -1,0 +1,73 @@
+#include <TheThingsNetwork.h>
+
+// Set your DevAddr, NwkSKey, AppSKey and the frequency plan
+const char *devAddr = "00000000";
+const char *nwkSKey = "00000000000000000000000000000000";
+const char *appSKey = "00000000000000000000000000000000";
+
+#define loraSerial Serial1
+#define debugSerial Serial
+
+// Replace REPLACE_ME with TTN_FP_EU868 or TTN_FP_US915
+#define freqPlan REPLACE_ME
+
+TheThingsNetwork ttn(loraSerial, debugSerial, freqPlan);
+
+void setup()
+{
+  loraSerial.begin(57600);
+  debugSerial.begin(9600);
+
+  // Wait a maximum of 10s for Serial Monitor
+  while (!debugSerial && millis() < 10000)
+    ;
+
+  // RN2XX3 reset pin connected to Arduino pin 12
+  pinMode(12, OUTPUT);
+  digitalWrite(12, HIGH);
+  // hard reset module and wait for startup
+  debugSerial.println("-- CHECK COMM");
+  ttn.resetHard(12);
+  delay(100);
+  // check if a valid module responded
+  // (if no module is connected or wiring is bad, checkValidModuleConnected() will
+  //  take about ~30s to return (another ~30s if autobaud_first is true))
+  if(!ttn.checkValidModuleConnected(true))
+  {
+    if(ttn.needsHardReset)
+    {
+      debugSerial.println("Module unresponsive, please power cycle or hard reset board!");
+    }
+    else
+    {
+      debugSerial.println("Module unsupported!");       // module must be RN2483, RN2483A, RN2903, RN2903AS
+    }
+    while(true)                                         // stop code execution
+    {
+      ;
+    }
+  }
+
+  // do an ABP join
+  debugSerial.println("-- PERSONALIZE");
+  // false is added as fourth argument to the personalize() call so that it
+  // does not perform a soft reset, because the module was already hard reset before via pin 12.
+  ttn.personalize(devAddr, nwkSKey, appSKey, false);
+
+  debugSerial.println("-- STATUS");
+  ttn.showStatus();
+}
+
+void loop()
+{
+  debugSerial.println("-- LOOP");
+
+  // Prepare payload of 1 byte to indicate LED status
+  byte payload[1];
+  payload[0] = (digitalRead(LED_BUILTIN) == HIGH) ? 1 : 0;
+
+  // Send it off
+  ttn.sendBytes(payload, sizeof(payload));
+
+  delay(10000);
+}

--- a/src/TheThingsNetwork.cpp
+++ b/src/TheThingsNetwork.cpp
@@ -689,9 +689,9 @@ void TheThingsNetwork::onMessage(void (*cb)(const uint8_t *payload, size_t size,
   messageCallback = cb;
 }
 
-bool TheThingsNetwork::personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool reset_first)
+bool TheThingsNetwork::personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool resetFirst)
 {
-  if(reset_first) {
+  if(resetFirst) {
     reset(adr);
   }
   if (strlen(devAddr) != 8 || strlen(appSKey) != 32 || strlen(nwkSKey) != 32)
@@ -723,9 +723,9 @@ bool TheThingsNetwork::personalize()
   return true;
 }
 
-bool TheThingsNetwork::provision(const char *appEui, const char *appKey, bool reset_first)
+bool TheThingsNetwork::provision(const char *appEui, const char *appKey, bool resetFirst)
 {
-  if(reset_first) {
+  if(resetFirst) {
     reset(adr);
   }
   if (strlen(appEui) != 16 || strlen(appKey) != 32)
@@ -939,10 +939,10 @@ void TheThingsNetwork::showStatus()
   debugPrintIndex(SHOW_RX_DELAY_2, buffer);
 }
 
-bool TheThingsNetwork::checkValidModuleConnected(bool autobaud_first)
+bool TheThingsNetwork::checkValidModuleConnected(bool autoBaudFirst)
 {
   // check if we want to autobaud first
-  if(autobaud_first)
+  if(autoBaudFirst)
   {
     autoBaud();
   }

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -157,10 +157,10 @@ public:
   bool getChannelStatus (uint8_t channel);
   ttn_response_code_t getLastError();
   void onMessage(void (*cb)(const uint8_t *payload, size_t size, port_t port));
-  bool provision(const char *appEui, const char *appKey, bool reset_first = true);
+  bool provision(const char *appEui, const char *appKey, bool resetFirst = true);
   bool join(const char *appEui, const char *appKey, int8_t retries = -1, uint32_t retryDelay = 10000, lorawan_class_t = CLASS_A);
   bool join(int8_t retries = -1, uint32_t retryDelay = 10000);
-  bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool reset_first = true);
+  bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool resetFirst = true);
   bool personalize();
   bool setClass(lorawan_class_t p_lw_class);
   ttn_response_t sendBytes(const uint8_t *payload, size_t length, port_t port = 1, bool confirm = false, uint8_t sf = 0);
@@ -181,7 +181,7 @@ public:
   bool setRX1Delay(uint16_t delay);
   bool setFCU(uint32_t fcu);
   bool setFCD(uint32_t fcd);
-  bool checkValidModuleConnected(bool autobaud_first = false);
+  bool checkValidModuleConnected(bool autoBaudFirst = false);
 };
 
 #endif

--- a/src/TheThingsNetwork.h
+++ b/src/TheThingsNetwork.h
@@ -140,6 +140,7 @@ public:
   void showStatus();
   size_t getHardwareEui(char *buffer, size_t size);
   size_t getAppEui(char *buffer, size_t size);
+  size_t getVersion(char *buffer, size_t size);
   enum ttn_modem_status_t getStatus();
   uint16_t getVDD();
   int16_t getRSSI();
@@ -156,10 +157,10 @@ public:
   bool getChannelStatus (uint8_t channel);
   ttn_response_code_t getLastError();
   void onMessage(void (*cb)(const uint8_t *payload, size_t size, port_t port));
-  bool provision(const char *appEui, const char *appKey);
+  bool provision(const char *appEui, const char *appKey, bool reset_first = true);
   bool join(const char *appEui, const char *appKey, int8_t retries = -1, uint32_t retryDelay = 10000, lorawan_class_t = CLASS_A);
   bool join(int8_t retries = -1, uint32_t retryDelay = 10000);
-  bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey);
+  bool personalize(const char *devAddr, const char *nwkSKey, const char *appSKey, bool reset_first = true);
   bool personalize();
   bool setClass(lorawan_class_t p_lw_class);
   ttn_response_t sendBytes(const uint8_t *payload, size_t length, port_t port = 1, bool confirm = false, uint8_t sf = 0);
@@ -180,6 +181,7 @@ public:
   bool setRX1Delay(uint16_t delay);
   bool setFCU(uint32_t fcu);
   bool setFCD(uint32_t fcd);
+  bool checkValidModuleConnected(bool autobaud_first = false);
 };
 
 #endif


### PR DESCRIPTION
This PR is related to #280 . I believe the handling of the `needsHardReset` flag could be improved, by not setting it to `false` with each call to `reset()`.

Additionally, I added a function called `checkValidModuleConnected()` to address https://github.com/TheThingsNetwork/arduino-device-lib/issues/216#issuecomment-310430834 . In this manner, the user application can call `checkValidModuleConnected()` in the `setup()` function of the Arduino code, and make sure a valid module is connected before any join attempt. This is especially important, because we need a function that returns as fast as possible when a module is not connected or incorrectly wired. For example, a call to `reset()` takes several minutes to return if a module is not connected, because of the many instructions carried out within it and the innate timeout given in `readLine()`. The `checkValidModuleConnected()` function returns in ~30s if `autobaud_first` is set to `false`, and ~60s if set to `true`.

I also added an example [CheckModule.ino](https://github.com/TheThingsNetwork/arduino-device-lib/blob/master/examples/CheckModule/CheckModule.ino) to showcase the usage of the `checkValidModuleConnected()` function.

Additionally, I added a `bool reset_first` to `personalize()` and `provision()`, so the user application can tell the library if they want a soft reset to be performed when calling these functions. For example, if a user performs:
1. Hard reset RN module
2. call `checkValidModuleConnected()`

Before calling `personalize()`, it would make sense to go directly into the ABP join, without a soft reset first, as the hard reset was already performed. Anyways, I set these params `true` by default so that prior behaviour is not broken.

Finally, I also updated the documentation.

### Help wanted:
**Broken:** The only caveat with this PR is that the module validation in `checkValidModuleConnected()` is not working as expected. This section in particular:

```c
  // buffer contains "RN2xx3[xx] x.x.x ...", getting only model (RN2xx3[xx])
  char *model = strtok(buffer, " ");
  debugPrintIndex(SHOW_MODEL, model);
  // check if module is valid (must be RN2483, RN2483A, RN2903 or RN2903AS)
  if(pgmstrcmp(model, CMP_RN2483) == 0 || pgmstrcmp(model, CMP_RN2483A) == 0 || pgmstrcmp(model, CMP_RN2903) == 0 || pgmstrcmp(model, CMP_RN2903AS) == 0)
  {
    debugPrintMessage(SUCCESS_MESSAGE, SCS_VALID_MODULE);
    return true;                                                // module responded and is valid (recognized/supported)
  }
```

For example, if `model = "RN2903AX"` (impossible, I know, but for the sake of the example), the function will think that this is a valid module, because `pgmstrcmp(model, CMP_RN2903) == 0` returns `true`. I am not so familiar with the c string functions. Could anyone help me by suggesting how to make the verification work correctly?

I went ahead and submitted the PR with this caveat, so that it may be reviewed and a fix to this small issue could be suggested.